### PR TITLE
Improve eigenmode setup diagnostics

### DIFF
--- a/index.html
+++ b/index.html
@@ -408,7 +408,8 @@
               </svg>
             </button>
           </div>
-          <canvas id="eigenPlot" class="eigen-plot" width="860" height="384" style="background:#0f1115;"></canvas>
+          <div id="eigenStatus" class="eigen-status" aria-live="polite" hidden></div>
+          <canvas id="eigenPlot" class="eigen-plot" width="860" height="384" style="background:#0f1115;" aria-label="Eigenmode plot"></canvas>
         </div>
       </div>
       <div id="githubStarMobile" class="github-star github-star-mobile">

--- a/js/dist/app.js
+++ b/js/dist/app.js
@@ -73,6 +73,7 @@ const els = {
   viewer: document.getElementById('viewer'),
   viewerAircraftName: document.getElementById('viewerAircraftName'),
   trefftz: document.getElementById('trefftz'),
+  eigenStatus: document.getElementById('eigenStatus'),
   eigenPlot: document.getElementById('eigenPlot'),
   eigenHome: document.getElementById('eigenHome'),
   eigenZoomIn: document.getElementById('eigenZoomIn'),
@@ -190,6 +191,7 @@ const uiState = {
   testControlDeflections: null,
   eigenModes: [],
   eigenModesByRunCase: {},
+  eigenStatusMessage: '',
   selectedEigenMode: -1,
   eigenPoints: [],
   eigenZoom: 1,
@@ -2716,6 +2718,7 @@ function activeRunCaseEntry() {
 function clearEigenModeRunCaseCache() {
   uiState.eigenModesByRunCase = {};
   uiState.eigenModes = [];
+  uiState.eigenStatusMessage = '';
   uiState.selectedEigenMode = -1;
   stopModeAnimation();
   drawEigenPlot();
@@ -3179,6 +3182,7 @@ function renderRunCasesList() {
       uiState.runCases.splice(idx, 1);
       uiState.eigenModesByRunCase = {};
       uiState.eigenModes = [];
+      uiState.eigenStatusMessage = '';
       uiState.selectedEigenMode = -1;
       stopModeAnimation();
       if (!uiState.runCases.length) {
@@ -3503,6 +3507,7 @@ function parseRunsPayload(text) {
 function applyLoadedRunCases(parsed, filename, source = 'Loaded', rawText = '') {
   uiState.eigenModesByRunCase = {};
   uiState.eigenModes = [];
+  uiState.eigenStatusMessage = '';
   uiState.selectedEigenMode = -1;
   stopModeAnimation();
   uiState.runCases = parsed.cases;
@@ -3592,6 +3597,7 @@ function resetAuxPanelsForNewAvl() {
   updateRunCasesMeta();
   uiState.eigenModesByRunCase = {};
   uiState.eigenModes = [];
+  uiState.eigenStatusMessage = '';
   uiState.selectedEigenMode = -1;
   stopModeAnimation();
   drawEigenPlot();
@@ -4487,6 +4493,7 @@ els.runCaseAddBtn?.addEventListener('click', () => {
   uiState.runCases.push(created);
   uiState.eigenModesByRunCase = {};
   uiState.eigenModes = [];
+  uiState.eigenStatusMessage = '';
   uiState.selectedEigenMode = -1;
   stopModeAnimation();
   uiState.selectedRunCaseIndex = uiState.runCases.length - 1;
@@ -5860,6 +5867,7 @@ if (typeof window !== 'undefined') {
     },
     setEigenModes(modes) {
       uiState.eigenModes = Array.isArray(modes) ? modes : [];
+      setEigenStatusMessage('');
       uiState.selectedEigenMode = -1;
       uiState.eigenZoom = 1;
       uiState.eigenCenterRe = 0;
@@ -5890,6 +5898,9 @@ if (typeof window !== 'undefined') {
     },
     getEigenViewport() {
       return uiState.eigenViewport ? { ...uiState.eigenViewport } : null;
+    },
+    getEigenStatusMessage() {
+      return String(uiState.eigenStatusMessage || '');
     },
     getRunCases() {
       return Array.isArray(uiState.runCases)
@@ -6858,6 +6869,44 @@ function computeEigenModesFromExec(result) {
   return [];
 }
 
+function eigenStatusMessageFromExec(result, modes = []) {
+  if (Array.isArray(modes) && modes.length) return '';
+  const raw = String(result?.EIGEN?.message || '').trim();
+  return raw || '';
+}
+
+function setEigenStatusMessage(message = '') {
+  const text = String(message || '').trim();
+  uiState.eigenStatusMessage = text;
+  if (els.eigenStatus) {
+    els.eigenStatus.textContent = text;
+    els.eigenStatus.hidden = !text;
+  }
+  if (els.eigenPlot) {
+    const label = text || 'Eigenmode plot';
+    els.eigenPlot.dataset.emptyMessage = text;
+    els.eigenPlot.setAttribute('aria-label', label);
+  }
+}
+
+function drawPlotMessage(ctx, text, x, y, maxWidth, lineHeight = 17) {
+  const words = String(text || '').split(/\s+/).filter(Boolean);
+  if (!words.length) return;
+  let line = '';
+  let lineNo = 0;
+  words.forEach((word) => {
+    const next = line ? `${line} ${word}` : word;
+    if (line && ctx.measureText(next).width > maxWidth) {
+      ctx.fillText(line, x, y + lineNo * lineHeight);
+      line = word;
+      lineNo += 1;
+    } else {
+      line = next;
+    }
+  });
+  if (line) ctx.fillText(line, x, y + lineNo * lineHeight);
+}
+
 function drawEigenPlot() {
   const canvas = els.eigenPlot;
   if (!canvas?.getContext) return;
@@ -6888,11 +6937,16 @@ function drawEigenPlot() {
   if (!modes.length) {
     uiState.eigenPoints = [];
     uiState.eigenViewport = null;
-    ctx.fillStyle = '#8ea2b8';
-    ctx.font = '12px Consolas, "Courier New", monospace';
-    ctx.fillText('No eigenmodes available yet. Run trim/EXEC first.', x0 + 8, y0 + 18);
+    const message = uiState.eigenStatusMessage || 'No eigenmodes available yet. Run trim/EXEC first.';
+    setEigenStatusMessage(message);
+    if (!els.eigenStatus) {
+      ctx.fillStyle = '#8ea2b8';
+      ctx.font = '12px Consolas, "Courier New", monospace';
+      drawPlotMessage(ctx, message, x0 + 8, y0 + 18, Math.max(120, pw - 16));
+    }
     return;
   }
+  setEigenStatusMessage('');
 
   let maxRe = 0.2;
   let maxIm = 0.2;
@@ -11574,6 +11628,7 @@ function applyExecResults(result) {
     ? (result.LNASA_SA ? -1.0 : 1.0)
     : -1.0;
   const computedEigenModes = computeEigenModesFromExec(result);
+  const eigenStatusMessage = eigenStatusMessageFromExec(result, computedEigenModes);
   const activeCaseIdx = activeRunCaseIndex();
   if (activeCaseIdx >= 0 && Array.isArray(uiState.runCases) && uiState.runCases.length) {
     if (!uiState.eigenModesByRunCase || typeof uiState.eigenModesByRunCase !== 'object') {
@@ -11591,6 +11646,7 @@ function applyExecResults(result) {
     uiState.eigenModesByRunCase = {};
     uiState.eigenModes = computedEigenModes.map((m) => ({ ...m, runCaseIndex: -1 }));
   }
+  setEigenStatusMessage(uiState.eigenModes.length ? '' : eigenStatusMessage);
   if (uiState.selectedEigenMode >= uiState.eigenModes.length) {
     uiState.selectedEigenMode = -1;
   }

--- a/js/dist/exec-worker.js
+++ b/js/dist/exec-worker.js
@@ -322,6 +322,39 @@ function normalizeEigenVec(vr, vi, nsys) {
   };
 }
 
+function eigenSetupDiagnostic(state, ir) {
+  const idx = (i, j) => idx2(i, j, state.IPTOT || 30);
+  const par = state.PARVAL || [];
+  const checks = [
+    ['velocity', state.IPVEE || 12, 'positive velocity'],
+    ['mass', state.IPMASS || 20, 'positive mass'],
+    ['Ixx', state.IPIXX || 21, 'positive Ixx'],
+    ['Iyy', state.IPIYY || 22, 'positive Iyy'],
+    ['Izz', state.IPIZZ || 23, 'positive Izz'],
+  ];
+  const missing = checks.filter(([, ip]) => {
+    const value = Number(par[idx(ip, ir)]);
+    return !Number.isFinite(value) || value <= 0;
+  });
+  if (!missing.length) return null;
+
+  const labels = missing.map(([label]) => label);
+  const inertiaLabels = labels.filter((label) => ['Ixx', 'Iyy', 'Izz'].includes(label));
+  if (inertiaLabels.length) {
+    const suffix = labels.includes('mass')
+      ? 'positive mass and principal inertias'
+      : `positive principal inertias (${inertiaLabels.join(', ')})`;
+    return `Eigenmodes need ${suffix}. Load a .mass file or enter positive mass-property values, then run Trim/EXEC again.`;
+  }
+  if (labels.includes('velocity')) {
+    return 'Eigenmodes need a positive flight velocity. Enter a positive Velocity value, then run Trim/EXEC again.';
+  }
+  if (labels.includes('mass')) {
+    return 'Eigenmodes need a positive mass. Load a .mass file or enter a positive Mass value, then run Trim/EXEC again.';
+  }
+  return `Eigenmodes need valid setup values: ${missing.map(([, , label]) => label).join(', ')}.`;
+}
+
 async function computeEigenmodes(state, useWasm) {
   ensureAmodeState(state);
   const IR = 1;
@@ -332,6 +365,11 @@ async function computeEigenmodes(state, useWasm) {
     } catch (err) {
       log(`APPGET failed: ${err?.message ?? err}`);
     }
+  }
+  const setupMessage = eigenSetupDiagnostic(state, IR);
+  if (setupMessage) {
+    log(`Eigenmodes unavailable: ${setupMessage}`);
+    return { nsys: 0, modes: [], status: 'invalid-setup', message: setupMessage };
   }
   let sysRes = null;
   let eigRes = null;
@@ -365,6 +403,11 @@ async function computeEigenmodes(state, useWasm) {
     eigRes = EIGSOL(state, IR, ETOL, ASYS, sysRes?.NSYS || 0);
   }
   const nsys = sysRes?.NSYS || 0;
+  if (!nsys || sysRes?.LTERR) {
+    const message = 'Eigenmodes could not be solved for this run case. Check mass, principal inertias, velocity, and duplicated constraints.';
+    log(`Eigenmodes unavailable: ${message}`);
+    return { nsys: 0, modes: [], status: 'sysmat-failed', message };
+  }
   const evals = eigRes?.EVAL || [];
   const evecs = eigRes?.EVEC || [];
   const names = ['u', 'w', 'q', 'theta', 'v', 'p', 'r', 'phi', 'x', 'y', 'z', 'psi'];

--- a/js/dist/styles.css
+++ b/js/dist/styles.css
@@ -924,6 +924,21 @@ textarea.code {
   touch-action: none;
 }
 
+.eigen-status {
+  position: absolute;
+  top: 34px;
+  left: 52px;
+  z-index: 4;
+  max-width: min(620px, calc(100% - 104px));
+  color: #fbbf24;
+  font: 12px/1.45 Consolas, "Courier New", monospace;
+  pointer-events: none;
+}
+
+.eigen-status[hidden] {
+  display: none;
+}
+
 .eigen-plot.pan-enabled {
   cursor: grab;
 }

--- a/js/playwright/eigenmode_invalid_mass_message.spec.js
+++ b/js/playwright/eigenmode_invalid_mass_message.spec.js
@@ -1,0 +1,48 @@
+import { test, expect } from '@playwright/test';
+import { startAppServer } from './helpers/app_test_harness.js';
+
+if (process.env.PLAYWRIGHT_CHANNEL) {
+  test.use({ channel: process.env.PLAYWRIGHT_CHANNEL });
+}
+
+test('ow example explains missing mass inertia instead of asking to rerun trim', async ({ page }) => {
+  test.setTimeout(90000);
+  const { server, baseUrl } = await startAppServer();
+
+  try {
+    await page.goto(`${baseUrl}/index.html?debug=1`, { waitUntil: 'domcontentloaded' });
+    await page.waitForFunction(() => typeof window.__trefftzTestHook !== 'undefined');
+    await page.waitForFunction(() => {
+      const select = document.querySelector('#loadExampleSelect');
+      return Boolean(select && [...select.querySelectorAll('option')].some((opt) => opt.value === 'ow.avl'));
+    }, { timeout: 30000 });
+
+    await page.selectOption('#loadExampleSelect', 'ow.avl');
+    await expect(page.locator('#fileMeta')).toContainText('Loaded example: ow.avl', { timeout: 30000 });
+    await expect.poll(async () => page.evaluate(() => {
+      const log = String(document.querySelector('#debugLog')?.textContent || '');
+      return log.includes('Worker EXEC done');
+    }), { timeout: 60000 }).toBe(true);
+
+    const status = page.locator('#eigenStatus');
+    await expect(status).toBeVisible();
+    await expect(status).toContainText('Eigenmodes need positive principal inertias');
+    await expect(status).toContainText('Ixx, Iyy, Izz');
+    await expect(status).toContainText('Load a .mass file');
+
+    const report = await page.evaluate(() => ({
+      hookMessage: window.__trefftzTestHook.getEigenStatusMessage(),
+      ariaLabel: document.querySelector('#eigenPlot')?.getAttribute('aria-label') || '',
+      points: window.__trefftzTestHook.getEigenPoints(),
+    }));
+    expect(report.hookMessage).toContain('positive principal inertias');
+    expect(report.ariaLabel).toContain('positive principal inertias');
+    expect(report.hookMessage).not.toContain('Run trim/EXEC first');
+    expect(report.points).toHaveLength(0);
+
+    const statusColor = await status.evaluate((el) => getComputedStyle(el).color);
+    expect(statusColor).toBe('rgb(251, 191, 36)');
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+});


### PR DESCRIPTION
Stack: 1 of 4 in the AVL visualization QoL stack.

## Summary
- Show an explicit eigenmode diagnostic when EXEC cannot compute eigenmodes because mass principal inertias are missing or invalid.
- Thread the worker-side EIGEN message through the app and expose it in the eigenmode panel and canvas aria label.
- Add an app-level Playwright regression for the `ow.avl` missing-inertia case.

## Screenshot
![Eigenmode missing inertia diagnostic](https://raw.githubusercontent.com/ghorn/vibelattice/greg/pr-screenshots/pr-screenshots/avl-visualization-stack/pr1/eigenmode-invalid-mass-status.png)

## Checks
- `node --check js/dist/app.js`
- `node --check js/dist/exec-worker.js`
- `npx playwright test js/playwright/eigenmode_invalid_mass_message.spec.js`
