### PR TITLE
Improve AVL plot interactions

### DIFF
--- a/index.html
+++ b/index.html
@@ -258,25 +258,25 @@
         <div id="viewer" class="viewer">
           <div id="viewerAircraftName" class="viewer-aircraft-name"></div>
           <div class="viewer-overlay">
-            <button class="viewer-btn icon-btn" id="viewerHome" type="button" title="Fit to model">
+            <button class="viewer-btn icon-btn" id="viewerHome" type="button" aria-label="Fit to model" data-tooltip="Fit to model">
               <svg viewBox="0 0 24 24" aria-hidden="true">
                 <path d="M4 11.5 12 5l8 6.5" />
                 <path d="M7 10.5v7h10v-7" />
               </svg>
             </button>
-            <button class="viewer-btn icon-btn" id="viewerZoomIn" type="button" title="Zoom in">
+            <button class="viewer-btn icon-btn" id="viewerZoomIn" type="button" aria-label="Zoom in" data-tooltip="Zoom in">
               <svg viewBox="0 0 24 24" aria-hidden="true">
                 <circle cx="11" cy="11" r="6" />
                 <path d="M11 8v6m-3-3h6M15.2 15.2l3.3 3.3" />
               </svg>
             </button>
-            <button class="viewer-btn icon-btn" id="viewerZoomOut" type="button" title="Zoom out">
+            <button class="viewer-btn icon-btn" id="viewerZoomOut" type="button" aria-label="Zoom out" data-tooltip="Zoom out">
               <svg viewBox="0 0 24 24" aria-hidden="true">
                 <circle cx="11" cy="11" r="6" />
                 <path d="M8 11h6M15.2 15.2l3.3 3.3" />
               </svg>
             </button>
-            <button class="viewer-btn icon-btn" id="viewerPan" type="button" title="Pan mode">
+            <button class="viewer-btn icon-btn" id="viewerPan" type="button" aria-label="Pan mode" data-tooltip="Pan mode">
               <svg viewBox="0 0 24 24" aria-hidden="true">
                 <path d="M12 5v14M5 12h14" />
                 <path d="M9 7 12 4l3 3" />
@@ -285,7 +285,7 @@
                 <path d="M17 9l3 3-3 3" />
               </svg>
             </button>
-            <button class="viewer-btn icon-btn" id="viewerView" type="button" title="Cycle view">
+            <button class="viewer-btn icon-btn" id="viewerView" type="button" aria-label="Cycle view" data-tooltip="Cycle view">
               <svg viewBox="0 0 24 24" aria-hidden="true">
                 <path d="M18 8.5a7.5 7.5 0 0 0-11.5-2.3" />
                 <path d="M6.5 6.2 8.6213 2.5257M6.5 6.2 10.1743 8.3213" />
@@ -293,43 +293,43 @@
                 <path d="M17.5 17.8 13.8257 15.6787M17.5 17.8 15.3787 21.4743" />
               </svg>
             </button>
-            <button class="viewer-btn icon-btn" id="viewerGrid" type="button" title="Cycle grid">
+            <button class="viewer-btn icon-btn" id="viewerGrid" type="button" aria-label="Cycle grid" data-tooltip="Cycle grid">
               <svg viewBox="0 0 24 24" aria-hidden="true">
                 <rect x="4" y="4" width="16" height="16" rx="1.5" />
                 <path d="M4 12h16M12 4v16" />
               </svg>
             </button>
-            <button class="viewer-btn icon-btn text-icon-btn" id="viewerText" type="button" title="Surface labels on" aria-label="Toggle surface labels">T</button>
-            <button class="viewer-btn icon-btn text-icon-btn" id="viewerMassPoints" type="button" title="Mass points off" aria-label="Toggle mass points">M</button>
+            <button class="viewer-btn icon-btn text-icon-btn" id="viewerText" type="button" aria-label="Surface labels on" data-tooltip="Surface labels on">T</button>
+            <button class="viewer-btn icon-btn text-icon-btn" id="viewerMassPoints" type="button" aria-label="Mass points off" data-tooltip="Mass points off">M</button>
           </div>
           <div class="viewer-overlay-bottom">
-            <button class="viewer-btn icon-btn" id="viewerSurface" type="button" title="Surface mode">
+            <button class="viewer-btn icon-btn" id="viewerSurface" type="button" aria-label="Surface mode" data-tooltip="Surface mode">
               <svg viewBox="0 0 24 24" aria-hidden="true">
                 <path d="M4 7l8-4 8 4-8 4-8-4z" />
                 <path d="M4 12l8 4 8-4" />
                 <path d="M4 17l8 4 8-4" />
               </svg>
             </button>
-            <button class="viewer-btn icon-btn" id="viewerPanelSpacing" type="button" title="Panel spacing">
+            <button class="viewer-btn icon-btn" id="viewerPanelSpacing" type="button" aria-label="Panel spacing" data-tooltip="Panel spacing">
               <svg viewBox="0 0 24 24" aria-hidden="true">
                 <rect x="4" y="4" width="16" height="16" rx="1.2" />
                 <path d="M4 9.5h16M4 14.5h16M9.5 4v16M14.5 4v16" />
               </svg>
             </button>
-            <button class="viewer-btn icon-btn" id="viewerVortices" type="button" title="Bound and leg vortices">
+            <button class="viewer-btn icon-btn" id="viewerVortices" type="button" aria-label="Bound and leg vortices" data-tooltip="Bound and leg vortices">
               <svg viewBox="0 0 24 24" aria-hidden="true">
                 <path d="M4 12h8" />
                 <path d="M12 12l4-4M12 12l4 4" />
                 <path d="M16 8h4M16 16h4" />
               </svg>
             </button>
-            <button class="viewer-btn icon-btn" id="viewerPressure" type="button" title="Toggle pressure">
+            <button class="viewer-btn icon-btn" id="viewerPressure" type="button" aria-label="Toggle pressure" data-tooltip="Toggle pressure">
               <svg viewBox="0 0 24 24" aria-hidden="true">
                 <path d="M12 3c2.8 3.7 5 6.2 5 9.2a5 5 0 1 1-10 0c0-3 2.2-5.5 5-9.2z" />
                 <path d="M9.3 13.2a2.9 2.9 0 0 0 2.7 2.8" />
               </svg>
             </button>
-            <button class="viewer-btn icon-btn" id="viewerLoad" type="button" title="Toggle loading">
+            <button class="viewer-btn icon-btn" id="viewerLoad" type="button" aria-label="Toggle loading" data-tooltip="Toggle loading">
               <svg viewBox="0 0 24 24" aria-hidden="true">
                 <path d="M4 19h16" />
                 <path d="M7 17V7" />
@@ -337,12 +337,20 @@
                 <path d="M17 17V9" />
               </svg>
             </button>
-            <button class="viewer-btn icon-btn" id="viewerFlow" type="button" title="Flow velocity field">
+            <button class="viewer-btn icon-btn" id="viewerFlow" type="button" aria-label="Flow velocity field" data-tooltip="Flow velocity field">
               <svg viewBox="0 0 24 24" aria-hidden="true">
                 <path d="M4 8h10" />
                 <path d="M4 12h14" />
                 <path d="M4 16h8" />
                 <path d="M12 6l2 2-2 2M16 10l2 2-2 2M10 14l2 2-2 2" />
+              </svg>
+            </button>
+            <button class="viewer-btn icon-btn" id="eigenDivergence" type="button" aria-label="Unstable mode growth off" data-tooltip="Unstable mode growth off" aria-pressed="false">
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M4.5 17.5c4.5-.2 7.5-2.2 9-6" />
+                <path d="M13.5 11.5c1.4-3 3.2-4.6 6-5" />
+                <path d="M16 5.5h3.5V9" />
+                <path d="M6.5 14.5 4.5 17.5l3 2" />
               </svg>
             </button>
           </div>
@@ -365,13 +373,13 @@
         <div class="panel-title">Eigenmodes</div>
         <div class="panel-body stage-panel-body">
           <div class="eigen-overlay" aria-label="Eigenmode plot controls">
-            <button class="viewer-btn icon-btn" id="eigenHome" type="button" title="Reset eigenmode view">
+            <button class="viewer-btn icon-btn" id="eigenHome" type="button" aria-label="Reset eigenmode view" data-tooltip="Reset eigenmode view">
               <svg viewBox="0 0 24 24" aria-hidden="true">
                 <path d="M4 11.5 12 5l8 6.5" />
                 <path d="M7.5 10.5V19h9v-8.5" />
               </svg>
             </button>
-            <button class="viewer-btn icon-btn" id="eigenZoomIn" type="button" title="Zoom in eigenmode plot">
+            <button class="viewer-btn icon-btn" id="eigenZoomIn" type="button" aria-label="Zoom in eigenmode plot" data-tooltip="Zoom in eigenmode plot">
               <svg viewBox="0 0 24 24" aria-hidden="true">
                 <circle cx="10" cy="10" r="5.5" />
                 <path d="M19 19l-4.3-4.3" />
@@ -379,14 +387,14 @@
                 <path d="M7.5 10h5" />
               </svg>
             </button>
-            <button class="viewer-btn icon-btn" id="eigenZoomOut" type="button" title="Zoom out eigenmode plot">
+            <button class="viewer-btn icon-btn" id="eigenZoomOut" type="button" aria-label="Zoom out eigenmode plot" data-tooltip="Zoom out eigenmode plot">
               <svg viewBox="0 0 24 24" aria-hidden="true">
                 <circle cx="10" cy="10" r="5.5" />
                 <path d="M19 19l-4.3-4.3" />
                 <path d="M7.5 10h5" />
               </svg>
             </button>
-            <button class="viewer-btn icon-btn" id="eigenPan" type="button" title="Pan eigenmode plot">
+            <button class="viewer-btn icon-btn" id="eigenPan" type="button" aria-label="Pan eigenmode plot" data-tooltip="Pan eigenmode plot">
               <svg viewBox="0 0 24 24" aria-hidden="true">
                 <path d="M12 4v16" />
                 <path d="M4 12h16" />
@@ -400,7 +408,15 @@
                 <path d="M20 12l-2.5 2.5" />
               </svg>
             </button>
-            <button class="viewer-btn icon-btn" id="eigenDownload" type="button" title="Download eigenmode CSV">
+            <button class="viewer-btn icon-btn" id="eigenScaleLock" type="button" aria-label="Keep real and imaginary axes to the same scale" data-tooltip="Keep real and imaginary axes to the same scale" aria-pressed="false">
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <rect x="6" y="6" width="12" height="12" rx="1.8" />
+                <path d="M8.5 15.5 15.5 8.5" />
+                <path d="M10.5 8.5h5v5" />
+                <path d="M13.5 15.5h-5v-5" />
+              </svg>
+            </button>
+            <button class="viewer-btn icon-btn" id="eigenDownload" type="button" aria-label="Download eigenmode CSV" data-tooltip="Download eigenmode CSV">
               <svg viewBox="0 0 24 24" aria-hidden="true">
                 <path d="M12 4v10" />
                 <path d="M8.5 11.5 12 15l3.5-3.5" />
@@ -639,7 +655,9 @@ rudder  1.0  0.0  0. 0. 0.  1
     })();
   </script>
   <script type="module">
-    import('./js/dist/app.js')
+    const appModuleUrl = new URL('./js/dist/app.js', import.meta.url);
+    appModuleUrl.search = window.location.search;
+    import(appModuleUrl.href)
       .then(() => window.__debugLog?.('App module loaded.'))
       .catch((err) => window.__debugLog?.(`App module failed: ${err?.message ?? err}`));
   </script>

--- a/js/dist/app.js
+++ b/js/dist/app.js
@@ -79,6 +79,8 @@ const els = {
   eigenZoomIn: document.getElementById('eigenZoomIn'),
   eigenZoomOut: document.getElementById('eigenZoomOut'),
   eigenPan: document.getElementById('eigenPan'),
+  eigenScaleLock: document.getElementById('eigenScaleLock'),
+  eigenDivergence: document.getElementById('eigenDivergence'),
   eigenDownload: document.getElementById('eigenDownload'),
   trefftzOverlay: document.getElementById('trefftzOverlay'),
   outAlpha: document.getElementById('outAlpha'),
@@ -198,7 +200,10 @@ const uiState = {
   eigenCenterRe: 0,
   eigenCenterIm: 0,
   eigenViewport: null,
+  eigenPlotRenderState: null,
   eigenPanMode: false,
+  eigenScaleLocked: false,
+  eigenShowDivergence: false,
   runCases: [],
   runCasesFilename: null,
   needsRunCaseConstraintSync: false,
@@ -270,6 +275,7 @@ let lastTrimState = null;
 let loadingGroup = null;
 let outputFontFitRaf = 0;
 let fileSummarySyncing = false;
+let syncingExpertGeometryDisclosure = false;
 
 function recordAutoUpdateTrace(stage, detail = '') {
   const entry = `${stage}${detail ? `:${detail}` : ''}`;
@@ -359,6 +365,176 @@ const TEMPLATE_POSITIVE_FIELD_INDICES = {
   surfaceSpacing: new Set([0, 2]),
   sectionData: new Set([3, 5]),
 };
+const EIGEN_MODE_DAMPING_TARGET = Math.SQRT1_2;
+const EIGEN_MODE_REAL_AXIS_TARGET = 1.0;
+const EIGEN_MODE_REAL_AXIS_SIGMA_FLOOR = 0.001;
+const EIGEN_MODE_COMPONENT_PENALTY_CAP = 4000;
+const EIGEN_MODE_QUALITY_PENALTY_CAP = 9000;
+const DESIGN_EIGEN_DEFAULT_STATE_ORDER = ['u', 'w', 'q', 'theta', 'v', 'p', 'r', 'phi', 'x', 'y', 'z', 'psi'];
+const DESIGN_EIGEN_TARGETS = {
+  worst: {
+    key: 'worstEigenReal',
+    label: 'Worst mode',
+    targetMax: -0.001,
+    neutralMax: 0,
+    hardMax: 0.08,
+    displayMin: -0.25,
+    digits: 4,
+  },
+  shortPeriod: {
+    key: 'eigenShortPeriod',
+    label: 'Short period',
+    targetMax: -0.020,
+    neutralMax: 0,
+    hardMax: 0.12,
+    displayMin: -0.45,
+    digits: 4,
+    dampingMin: EIGEN_MODE_DAMPING_TARGET,
+    dampingSoftMin: 0.35,
+    dampingPenaltyWeight: 1.4,
+    dampingBarrierWeight: 1.5,
+    cyclesToHalfMax: 0.35,
+    halfLifeMax: 1.5,
+    realAxisRatioPreferred: EIGEN_MODE_REAL_AXIS_TARGET,
+    realAxisRatioActive: 1.6,
+    realAxisPenaltyWeight: 1.0,
+    realAxisBarrierWeight: 1.4,
+  },
+  phugoid: {
+    key: 'eigenPhugoid',
+    label: 'Phugoid',
+    targetMax: -0.001,
+    neutralMax: 0,
+    hardMax: 0.05,
+    displayMin: -0.08,
+    digits: 4,
+    dampingMin: 0.08,
+    dampingSoftMin: 0.015,
+    dampingPreferred: 0.16,
+    dampingPenaltyWeight: 0.18,
+    dampingBarrierWeight: 0.25,
+    cyclesToHalfMax: 8.0,
+    halfLifeMax: 18.0,
+    realAxisRatioPreferred: 12.0,
+    realAxisRatioActive: 40.0,
+    realAxisPenaltyWeight: 0.05,
+    realAxisBarrierWeight: 0.08,
+  },
+  dutchRoll: {
+    key: 'eigenDutchRoll',
+    label: 'Dutch roll',
+    targetMax: -0.010,
+    neutralMax: 0,
+    hardMax: 0.10,
+    displayMin: -0.25,
+    digits: 4,
+    dampingMin: EIGEN_MODE_DAMPING_TARGET,
+    dampingSoftMin: 0.35,
+    dampingPenaltyWeight: 2.2,
+    dampingBarrierWeight: 3.0,
+    cyclesToHalfMax: 0.35,
+    halfLifeMax: 1.8,
+    realAxisRatioPreferred: EIGEN_MODE_REAL_AXIS_TARGET,
+    realAxisRatioActive: 1.6,
+    realAxisPenaltyWeight: 1.8,
+    realAxisBarrierWeight: 3.0,
+  },
+  spiral: {
+    key: 'eigenSpiral',
+    label: 'Spiral',
+    targetMax: -0.001,
+    neutralMax: 0,
+    hardMax: 0.05,
+    displayMin: -0.08,
+    digits: 4,
+  },
+  rollSubsidence: {
+    key: 'eigenRollSubsidence',
+    label: 'Roll subsidence',
+    targetMax: -0.020,
+    neutralMax: 0,
+    hardMax: 0.12,
+    displayMin: -0.45,
+    digits: 4,
+  },
+  lateralOscillation: {
+    key: 'eigenLateralOscillation',
+    label: 'Lateral osc.',
+    targetMax: -0.010,
+    neutralMax: 0,
+    hardMax: 0.08,
+    displayMin: -0.16,
+    digits: 4,
+    dampingMin: EIGEN_MODE_DAMPING_TARGET,
+    dampingSoftMin: 0.45,
+    dampingPenaltyWeight: 3.0,
+    dampingBarrierWeight: 5.0,
+    cyclesToHalfMax: 0.25,
+    halfLifeMax: 1.5,
+    realAxisRatioPreferred: EIGEN_MODE_REAL_AXIS_TARGET,
+    realAxisRatioActive: 1.4,
+    realAxisPenaltyWeight: 2.5,
+    realAxisBarrierWeight: 5.0,
+  },
+  pitchSubsidence: {
+    key: 'eigenPitchSubsidence',
+    label: 'Pitch subsidence',
+    targetMax: -0.010,
+    neutralMax: 0,
+    hardMax: 0.08,
+    displayMin: -0.20,
+    digits: 4,
+  },
+  longitudinalDrift: {
+    key: 'eigenLongitudinalDrift',
+    label: 'Long. drift',
+    targetMax: -0.001,
+    neutralMax: 0,
+    hardMax: 0.05,
+    displayMin: -0.08,
+    digits: 4,
+  },
+  unknown: {
+    key: 'eigenUnknown',
+    label: 'Unknown mode',
+    targetMax: -0.001,
+    neutralMax: 0,
+    hardMax: 0.08,
+    displayMin: -0.16,
+    digits: 4,
+  },
+};
+const DESIGN_EIGEN_CLASS_ORDER = [
+  'shortPeriod',
+  'phugoid',
+  'dutchRoll',
+  'spiral',
+  'rollSubsidence',
+  'lateralOscillation',
+  'pitchSubsidence',
+  'longitudinalDrift',
+  'unknown',
+];
+const DESIGN_EIGEN_ASSIGNABLE_CLASSES = [
+  'shortPeriod',
+  'phugoid',
+  'dutchRoll',
+  'rollSubsidence',
+  'spiral',
+  'pitchSubsidence',
+  'longitudinalDrift',
+  'lateralOscillation',
+];
+const DESIGN_EIGEN_CLASS_SCORE_MIN = 0.58;
+const EIGEN_PLOT_MIN_ZOOM = 0.5;
+const EIGEN_PLOT_MAX_ZOOM = 64;
+const EIGEN_PLOT_BOX_MIN_PX = 8;
+const EIGEN_MODE_ANIMATION_REAL_SCALE = 0.25;
+const EIGEN_MODE_ANIMATION_DIVERGENCE_INITIAL_AMPLITUDE = 0.08;
+const EIGEN_MODE_ANIMATION_DIVERGENCE_RESET_SPANS = 3;
+const EIGEN_MODE_ANIMATION_DIVERGENCE_SAFETY_CAP = 1e6;
+const VIEWER_SKIN_FILL_EMISSIVE_INTENSITY = 0.24;
+const VIEWER_PRESSURE_OVERLAY_FILL_EMISSIVE_INTENSITY = 0.08;
 const EXAMPLE_MANIFEST_FILENAME = 'examples.json';
 const FALLBACK_EXAMPLE_AVL_FILES = [
   'al.avl',
@@ -695,6 +871,12 @@ function clampNumber(value, min, max) {
     hi = tmp;
   }
   return Math.min(hi, Math.max(lo, value));
+}
+
+function finiteNumber(value) {
+  if (value === null || value === undefined || value === '') return Number.NaN;
+  const number = Number(value);
+  return Number.isFinite(number) ? number : Number.NaN;
 }
 
 function parseTemplateNumberToken(token) {
@@ -1127,6 +1309,8 @@ function getTemplateParamPositiveFloor(param) {
   return decimalStep;
 }
 
+
+
 function buildTemplateParamList(rawText) {
   const text = String(rawText || '');
   const prevMap = new Map();
@@ -1327,6 +1511,103 @@ function queueTemplateParamApply() {
   }, 80);
 }
 
+function hasHorizontalOverflow(container, itemSelector) {
+  if (!container) return false;
+  const nodes = container.querySelectorAll(itemSelector);
+  for (const node of nodes) {
+    if (!(node instanceof HTMLElement)) continue;
+    if (node.offsetParent === null) continue;
+    if (node.scrollWidth - node.clientWidth > 1) return true;
+  }
+  return false;
+}
+
+function fitGridFontVar({
+  grid,
+  cssVar,
+  maxPx,
+  minPx,
+  stepPx,
+  itemSelector,
+  extraOverflowCheck = null,
+}) {
+  if (!grid) return;
+  let size = maxPx;
+  grid.style.setProperty(cssVar, `${size.toFixed(2)}px`);
+  let overflow = hasHorizontalOverflow(grid, itemSelector) || (typeof extraOverflowCheck === 'function' && extraOverflowCheck());
+  while (overflow && size > minPx) {
+    size = Math.max(minPx, size - stepPx);
+    grid.style.setProperty(cssVar, `${size.toFixed(2)}px`);
+    overflow = hasHorizontalOverflow(grid, itemSelector) || (typeof extraOverflowCheck === 'function' && extraOverflowCheck());
+  }
+}
+
+function fitOutputGridFontsNow() {
+  fitGridFontVar({
+    grid: els.outTotalForces,
+    cssVar: '--forces-font-size',
+    maxPx: 16,
+    minPx: 8,
+    stepPx: 0.25,
+    itemSelector: '.force-cell:not(.control-row)',
+  });
+
+  fitGridFontVar({
+    grid: els.outStability,
+    cssVar: '--deriv-font-size',
+    maxPx: 14,
+    minPx: 7.5,
+    stepPx: 0.25,
+    itemSelector: '.stability-cell',
+    extraOverflowCheck: () => {
+      const n = els.outStabilityNeutral;
+      if (!(n instanceof HTMLElement) || n.offsetParent === null) return false;
+      return n.scrollWidth - n.clientWidth > 1;
+    },
+  });
+
+  fitGridFontVar({
+    grid: els.outBodyDeriv,
+    cssVar: '--deriv-font-size',
+    maxPx: 14,
+    minPx: 7,
+    stepPx: 0.25,
+    itemSelector: '.stability-cell',
+  });
+
+  fitGridFontVar({
+    grid: els.outForcesSurface,
+    cssVar: '--surface-font-size',
+    maxPx: 14,
+    minPx: 7,
+    stepPx: 0.25,
+    itemSelector: '.stability-cell',
+  });
+}
+
+function updateSurfaceNameColumnWidth() {
+  if (!els.outForcesSurface) return;
+  const names = [...els.outForcesSurface.querySelectorAll('.surface-name-text')]
+    .map((el) => String(el.textContent || '').trim())
+    .filter(Boolean);
+  if (!names.length) {
+    els.outForcesSurface.style.removeProperty('--surface-name-col');
+    return;
+  }
+  const maxChars = names.reduce((m, s) => Math.max(m, s.length), 0);
+  const widthCh = Math.max(8, Math.min(32, maxChars + 1));
+  els.outForcesSurface.style.setProperty('--surface-name-col', `${widthCh}ch`);
+}
+
+function scheduleOutputGridFontFit() {
+  if (outputFontFitRaf) return;
+  outputFontFitRaf = requestAnimationFrame(() => {
+    outputFontFitRaf = 0;
+    fitOutputGridFontsNow();
+  });
+}
+
+
 function renderTemplateParamControls() {
   if (!els.templateParamsPanel || !els.templateParamsList) return;
   const params = Array.isArray(uiState.templateParams) ? uiState.templateParams : [];
@@ -1524,162 +1805,506 @@ function resolveTemplateParamsInText(rawText) {
   });
 }
 
-function hasHorizontalOverflow(container, itemSelector) {
-  if (!container) return false;
-  const nodes = container.querySelectorAll(itemSelector);
-  for (const node of nodes) {
-    if (!(node instanceof HTMLElement)) continue;
-    if (node.offsetParent === null) continue;
-    if (node.scrollWidth - node.clientWidth > 1) return true;
-  }
-  return false;
+
+function eigenVectorComplexMagnitude(re, im) {
+  const r = Number(re);
+  const i = Number(im);
+  return Math.hypot(Number.isFinite(r) ? r : 0, Number.isFinite(i) ? i : 0);
 }
 
-function fitGridFontVar({
-  grid,
-  cssVar,
-  maxPx,
-  minPx,
-  stepPx,
-  itemSelector,
-  extraOverflowCheck = null,
-}) {
-  if (!grid) return;
-  let size = maxPx;
-  grid.style.setProperty(cssVar, `${size.toFixed(2)}px`);
-  let overflow = hasHorizontalOverflow(grid, itemSelector) || (typeof extraOverflowCheck === 'function' && extraOverflowCheck());
-  while (overflow && size > minPx) {
-    size = Math.max(minPx, size - stepPx);
-    grid.style.setProperty(cssVar, `${size.toFixed(2)}px`);
-    overflow = hasHorizontalOverflow(grid, itemSelector) || (typeof extraOverflowCheck === 'function' && extraOverflowCheck());
-  }
-}
-
-function fitOutputGridFontsNow() {
-  fitGridFontVar({
-    grid: els.outTotalForces,
-    cssVar: '--forces-font-size',
-    maxPx: 16,
-    minPx: 8,
-    stepPx: 0.25,
-    itemSelector: '.force-cell:not(.control-row)',
-  });
-
-  fitGridFontVar({
-    grid: els.outStability,
-    cssVar: '--deriv-font-size',
-    maxPx: 14,
-    minPx: 7.5,
-    stepPx: 0.25,
-    itemSelector: '.stability-cell',
-    extraOverflowCheck: () => {
-      const n = els.outStabilityNeutral;
-      if (!(n instanceof HTMLElement) || n.offsetParent === null) return false;
-      return n.scrollWidth - n.clientWidth > 1;
-    },
-  });
-
-  fitGridFontVar({
-    grid: els.outBodyDeriv,
-    cssVar: '--deriv-font-size',
-    maxPx: 14,
-    minPx: 7,
-    stepPx: 0.25,
-    itemSelector: '.stability-cell',
-  });
-
-  fitGridFontVar({
-    grid: els.outForcesSurface,
-    cssVar: '--surface-font-size',
-    maxPx: 14,
-    minPx: 7,
-    stepPx: 0.25,
-    itemSelector: '.stability-cell',
-  });
-}
-
-function updateSurfaceNameColumnWidth() {
-  if (!els.outForcesSurface) return;
-  const names = [...els.outForcesSurface.querySelectorAll('.surface-name-text')]
-    .map((el) => String(el.textContent || '').trim())
-    .filter(Boolean);
-  if (!names.length) {
-    els.outForcesSurface.style.removeProperty('--surface-name-col');
-    return;
-  }
-  const maxChars = names.reduce((m, s) => Math.max(m, s.length), 0);
-  const widthCh = Math.max(8, Math.min(32, maxChars + 1));
-  els.outForcesSurface.style.setProperty('--surface-name-col', `${widthCh}ch`);
-}
-
-function scheduleOutputGridFontFit() {
-  if (outputFontFitRaf) return;
-  outputFontFitRaf = requestAnimationFrame(() => {
-    outputFontFitRaf = 0;
-    fitOutputGridFontsNow();
-  });
-}
-
-function isAvlCommentLine(line) {
-  const t = String(line || '').trim();
-  return !t || t.startsWith('#') || t.startsWith('!') || t.startsWith('%');
-}
-
-function replaceAvlTitleLine(text, title) {
-  const lineBreak = text.includes('\r\n') ? '\r\n' : '\n';
-  const lines = String(text || '').split(/\r?\n/);
-  for (let i = 0; i < lines.length; i += 1) {
-    if (isAvlCommentLine(lines[i])) continue;
-    lines[i] = title;
-    return lines.join(lineBreak);
-  }
-  return title;
-}
-
-function replaceAvlHeaderReferenceLines(text, refs) {
-  const formatByToken = (value, token, options = {}) => {
-    const { minDecimals = 1, integer = false } = options;
-    const v = Number(value);
-    if (!Number.isFinite(v)) return integer ? '0' : '0.0';
-    if (integer) return String(Math.trunc(v));
-    const tokenText = String(token || '');
-    const frac = tokenText.match(/\.(\d+)/);
-    const decimals = Math.max(minDecimals, frac ? frac[1].length : 0);
-    return v.toFixed(decimals);
-  };
-
-  const rewriteTriple = (line, values, options = [{}, {}, {}]) => {
-    const m = String(line).match(/^(\s*)(\S+)(\s+)(\S+)(\s+)(\S+)(\s*)$/);
-    if (!m) {
-      return `${formatByToken(values[0], '', options[0])}  ${formatByToken(values[1], '', options[1])}  ${formatByToken(values[2], '', options[2])}`;
+function designEigenStateMagnitudes(mode) {
+  const out = Object.fromEntries(DESIGN_EIGEN_DEFAULT_STATE_ORDER.map((name) => [name, 0]));
+  const order = Array.isArray(mode?.stateOrder) && mode.stateOrder.length
+    ? mode.stateOrder.map((name) => String(name || '').trim().toLowerCase())
+    : DESIGN_EIGEN_DEFAULT_STATE_ORDER;
+  const eig = mode?.eigenvector || null;
+  const re = Array.isArray(eig?.re) ? eig.re : null;
+  const im = Array.isArray(eig?.im) ? eig.im : null;
+  if (re && im) {
+    const count = Math.min(order.length, re.length, im.length);
+    for (let i = 0; i < count; i += 1) {
+      const name = order[i];
+      if (!name) continue;
+      out[name] = Math.max(Number(out[name]) || 0, eigenVectorComplexMagnitude(re[i], im[i]));
     }
-    const [, lead, t1, s1, t2, s2, t3, trail] = m;
-    const n1 = formatByToken(values[0], t1, options[0]);
-    const n2 = formatByToken(values[1], t2, options[1]);
-    const n3 = formatByToken(values[2], t3, options[2]);
-    return `${lead}${n1}${s1}${n2}${s2}${n3}${trail}`;
-  };
-
-  const lineBreak = text.includes('\r\n') ? '\r\n' : '\n';
-  const lines = String(text || '').split(/\r?\n/);
-  const dataLineIdx = [];
-  for (let i = 0; i < lines.length; i += 1) {
-    if (!isAvlCommentLine(lines[i])) dataLineIdx.push(i);
-    if (dataLineIdx.length >= 5) break;
   }
-  if (dataLineIdx.length < 5) return text;
-  const symIdx = dataLineIdx[2];
-  const srefIdx = dataLineIdx[3];
-  const xrefIdx = dataLineIdx[4];
-  lines[symIdx] = rewriteTriple(
-    lines[symIdx],
-    [refs.iysym, refs.izsym, refs.zsym],
-    [{ integer: true, minDecimals: 0 }, { integer: true, minDecimals: 0 }, { minDecimals: 1 }],
-  );
-  lines[srefIdx] = rewriteTriple(lines[srefIdx], [refs.sref, refs.cref, refs.bref]);
-  lines[xrefIdx] = rewriteTriple(lines[xrefIdx], [refs.xref, refs.yref, refs.zref]);
-  return lines.join(lineBreak);
+  if (!Object.values(out).some((value) => Number(value) > 0)) {
+    const vec = mode?.vec || {};
+    out.u = Math.abs(Number(vec.tx) || 0);
+    out.v = Math.abs(Number(vec.ty) || 0);
+    out.w = Math.abs(Number(vec.tz) || 0);
+    out.p = Math.abs(Number(vec.rx) || 0);
+    out.q = Math.abs(Number(vec.ry) || 0);
+    out.r = Math.abs(Number(vec.rz) || 0);
+    out.phi = out.p * 0.6;
+    out.theta = out.q * 0.6;
+    out.psi = out.r * 0.6;
+  }
+  return out;
 }
+
+function designEigenStateSum(magnitudes, names) {
+  return names.reduce((sum, name) => sum + (Number(magnitudes?.[name]) || 0), 0);
+}
+
+function designEigenModeFeatures(mode) {
+  const re = Number(mode?.re);
+  const im = Number(mode?.im);
+  const mag = designEigenStateMagnitudes(mode);
+  const longitudinal = designEigenStateSum(mag, ['u', 'w', 'q', 'theta', 'x', 'z']);
+  const lateral = designEigenStateSum(mag, ['v', 'p', 'r', 'phi', 'y', 'psi']);
+  const pitch = designEigenStateSum(mag, ['q', 'theta', 'w']);
+  const surge = designEigenStateSum(mag, ['u', 'x', 'z']);
+  const roll = designEigenStateSum(mag, ['p', 'phi']);
+  const yaw = designEigenStateSum(mag, ['v', 'r', 'psi', 'y']);
+  const total = longitudinal + lateral;
+  const absIm = Math.abs(Number.isFinite(im) ? im : 0);
+  const absRe = Math.abs(Number.isFinite(re) ? re : 0);
+  return {
+    re,
+    im,
+    absIm,
+    absRe,
+    longitudinal,
+    lateral,
+    pitch,
+    surge,
+    roll,
+    yaw,
+    total,
+    longRatio: total > 1e-10 ? longitudinal / total : 0,
+    latRatio: total > 1e-10 ? lateral / total : 0,
+    pitchRatio: (pitch + surge) > 1e-10 ? pitch / (pitch + surge) : 0,
+    surgeRatio: (pitch + surge) > 1e-10 ? surge / (pitch + surge) : 0,
+    rollRatio: (roll + yaw) > 1e-10 ? roll / (roll + yaw) : 0,
+    yawRatio: (roll + yaw) > 1e-10 ? yaw / (roll + yaw) : 0,
+    oscillatory: absIm > 1e-4,
+  };
+}
+
+function designEigenScoreForClass(features, classKey) {
+  const f = features || {};
+  const clamp01 = (value) => Math.max(0, Math.min(1, Number(value) || 0));
+  const osc = Boolean(f.oscillatory);
+  const longRatio = clamp01(f.longRatio);
+  const latRatio = clamp01(f.latRatio);
+  const pitchRatio = clamp01(f.pitchRatio);
+  const surgeRatio = clamp01(f.surgeRatio);
+  const rollRatio = clamp01(f.rollRatio);
+  const yawRatio = clamp01(f.yawRatio);
+  const absIm = Math.max(0, Number(f.absIm) || 0);
+  const absRe = Math.max(0, Number(f.absRe) || 0);
+  const highFreq = clamp01(absIm / 0.9);
+  const lowFreq = 1 - clamp01(absIm / 0.9);
+  const realRoot = osc ? 0 : 1;
+  if (classKey === 'shortPeriod') {
+    if (!osc) return 0;
+    return clamp01((0.52 * longRatio) + (0.34 * pitchRatio) + (0.14 * highFreq) - (surgeRatio > 0.70 ? 0.18 : 0));
+  }
+  if (classKey === 'phugoid') {
+    if (!osc) return 0;
+    return clamp01((0.52 * longRatio) + (0.34 * surgeRatio) + (0.14 * lowFreq) - (pitchRatio > 0.66 ? 0.25 : 0));
+  }
+  if (classKey === 'dutchRoll') {
+    if (!osc) return 0;
+    return clamp01((0.54 * latRatio) + (0.34 * yawRatio) + (0.12 * clamp01(absIm / 0.45)) - (rollRatio > 0.72 ? 0.12 : 0));
+  }
+  if (classKey === 'lateralOscillation') {
+    if (!osc) return 0;
+    return clamp01((0.58 * latRatio) + (0.26 * rollRatio) + (0.16 * clamp01(absIm / 0.45)) - (yawRatio > 0.72 ? 0.12 : 0));
+  }
+  if (classKey === 'rollSubsidence') {
+    return clamp01((0.50 * realRoot) + (0.26 * latRatio) + (0.18 * rollRatio) + (0.06 * clamp01(absRe / 0.08)) - (absRe < 0.002 ? 0.16 : 0));
+  }
+  if (classKey === 'spiral') {
+    return clamp01((0.50 * realRoot) + (0.26 * latRatio) + (0.18 * yawRatio) + (0.06 * (1 - clamp01(absRe / 0.08))) - (rollRatio > 0.70 ? 0.16 : 0));
+  }
+  if (classKey === 'pitchSubsidence') {
+    return clamp01((0.50 * realRoot) + (0.30 * longRatio) + (0.20 * pitchRatio) - (absRe < 0.002 ? 0.12 : 0));
+  }
+  if (classKey === 'longitudinalDrift') {
+    return clamp01((0.50 * realRoot) + (0.30 * longRatio) + (0.20 * surgeRatio) - (absRe > 0.12 ? 0.14 : 0));
+  }
+  return 0;
+}
+
+function designEigenOscillationMetrics(re, im) {
+  const sigma = Number(re);
+  const omega = Math.abs(Number(im));
+  if (!Number.isFinite(sigma) || !Number.isFinite(omega) || omega <= 1e-4) {
+    return {
+      oscillatory: false,
+      sigma,
+      omega,
+      dampingRatio: Number.NaN,
+      realAxisRatio: Number.NaN,
+      naturalFrequency: Number.NaN,
+      period: Number.NaN,
+      halfLife: Number.NaN,
+      cyclesToHalf: Number.NaN,
+    };
+  }
+  const naturalFrequency = Math.hypot(sigma, omega);
+  const dampingRatio = naturalFrequency > 1e-9 ? -sigma / naturalFrequency : Number.NaN;
+  const realAxisRatio = omega / Math.max(EIGEN_MODE_REAL_AXIS_SIGMA_FLOOR, -sigma);
+  const period = (Math.PI * 2) / omega;
+  const halfLife = sigma < -1e-9 ? Math.LN2 / -sigma : Number.NaN;
+  const cyclesToHalf = Number.isFinite(halfLife) && Number.isFinite(period) && period > 1e-9
+    ? halfLife / period
+    : Number.NaN;
+  return {
+    oscillatory: true,
+    sigma,
+    omega,
+    dampingRatio,
+    realAxisRatio,
+    naturalFrequency,
+    period,
+    halfLife,
+    cyclesToHalf,
+  };
+}
+
+function designEigenQualityComponents(row = {}, spec = {}) {
+  const sigma = Number(row?.sigma);
+  const dampingMin = Number(spec?.dampingMin);
+  const dampingPreferred = Number.isFinite(Number(spec?.dampingPreferred)) ? Number(spec.dampingPreferred) : dampingMin;
+  const zeta = Number(row?.dampingRatio);
+  const dampingSoftMin = Number(spec?.dampingSoftMin);
+  const cyclesMax = Number(spec?.cyclesToHalfMax);
+  const halfLifeMax = Number(spec?.halfLifeMax);
+  const axisPreferred = Number(spec?.realAxisRatioPreferred);
+  const axisActive = Number(spec?.realAxisRatioActive);
+  const axisRatio = Number(row?.realAxisRatio);
+  const dampingWeight = Number.isFinite(Number(spec?.dampingPenaltyWeight)) ? Number(spec.dampingPenaltyWeight) : 1;
+  const dampingBarrierWeight = Number.isFinite(Number(spec?.dampingBarrierWeight)) ? Number(spec.dampingBarrierWeight) : 1;
+  const axisWeight = Number.isFinite(Number(spec?.realAxisPenaltyWeight)) ? Number(spec.realAxisPenaltyWeight) : 1;
+  const axisBarrierWeight = Number.isFinite(Number(spec?.realAxisBarrierWeight)) ? Number(spec.realAxisBarrierWeight) : 4;
+  const components = {
+    damping: 0,
+    dampingBarrier: 0,
+    axis: 0,
+    axisBarrier: 0,
+    cycles: 0,
+    halfLife: 0,
+    instability: 0,
+  };
+  if (Number.isFinite(sigma) && sigma > 0) {
+    components.instability = 12 + Math.pow(sigma / 0.025, 2);
+  }
+  if (Number.isFinite(dampingPreferred) && Number.isFinite(zeta) && zeta < dampingPreferred) {
+    components.damping = Math.pow((dampingPreferred - zeta) / Math.max(0.01, Math.abs(dampingPreferred)), 2) * dampingWeight;
+  }
+  if (Number.isFinite(dampingSoftMin) && Number.isFinite(zeta) && zeta < dampingSoftMin) {
+    components.dampingBarrier = Math.pow((dampingSoftMin - zeta) / Math.max(0.01, Math.abs(dampingSoftMin)), 2) * dampingBarrierWeight;
+  }
+  if (Number.isFinite(axisPreferred) && axisPreferred > 0 && Number.isFinite(axisRatio)) {
+    components.axis = Math.pow(Math.max(0, axisRatio - axisPreferred) / axisPreferred, 2) * axisWeight;
+    if (Number.isFinite(axisActive) && axisActive > axisPreferred) {
+      components.axisBarrier = Math.pow(Math.max(0, axisRatio - axisActive) / axisActive, 2) * axisBarrierWeight;
+    }
+  }
+  if (Number.isFinite(cyclesMax) && cyclesMax > 0 && Number.isFinite(Number(row?.cyclesToHalf))) {
+    components.cycles = Math.pow(Math.max(0, Number(row.cyclesToHalf) - cyclesMax) / cyclesMax, 2) * 0.60;
+  }
+  if (Number.isFinite(halfLifeMax) && halfLifeMax > 0 && Number.isFinite(Number(row?.halfLife))) {
+    components.halfLife = Math.pow(Math.max(0, Number(row.halfLife) - halfLifeMax) / halfLifeMax, 2) * 0.75;
+  }
+  Object.keys(components).forEach((key) => {
+    components[key] = Math.min(
+      EIGEN_MODE_COMPONENT_PENALTY_CAP,
+      Math.max(0, Number(components[key]) || 0),
+    );
+  });
+  const multiplier = Number.isFinite(Number(spec?.qualityPenaltyWeight)) ? Number(spec.qualityPenaltyWeight) : 1;
+  const rawTotal = Object.values(components).reduce((sum, value) => sum + (Number(value) || 0), 0) * multiplier;
+  const total = Math.min(EIGEN_MODE_QUALITY_PENALTY_CAP, rawTotal);
+  return { ...components, multiplier, rawTotal, total };
+}
+
+function designEigenQualityPenalty(row = {}, spec = {}) {
+  return designEigenQualityComponents(row, spec).total;
+}
+
+function designEigenBestClassForFeatures(features, usedClasses = new Set()) {
+  let best = {
+    classKey: 'unknown',
+    classLabel: 'Unclassified',
+    confidence: 0,
+  };
+  DESIGN_EIGEN_ASSIGNABLE_CLASSES.forEach((key) => {
+    if (usedClasses.has(key)) return;
+    const score = designEigenScoreForClass(features, key);
+    if (score > best.confidence) {
+      const target = DESIGN_EIGEN_TARGETS[key] || DESIGN_EIGEN_TARGETS.unknown;
+      best = {
+        classKey: key,
+        classLabel: target.label,
+        confidence: score,
+      };
+    }
+  });
+  if (best.confidence < DESIGN_EIGEN_CLASS_SCORE_MIN) {
+    return {
+      classKey: 'unknown',
+      classLabel: 'Unclassified',
+      confidence: best.confidence,
+    };
+  }
+  return best;
+}
+
+function classifyDesignEigenMode(mode) {
+  const features = designEigenModeFeatures(mode);
+  const best = designEigenBestClassForFeatures(features);
+  return {
+    classKey: best.classKey,
+    classLabel: best.classLabel,
+    confidence: best.confidence,
+    participation: {
+      longitudinal: features.longitudinal,
+      lateral: features.lateral,
+      pitch: features.pitch,
+      surge: features.surge,
+      roll: features.roll,
+      yaw: features.yaw,
+    },
+  };
+}
+
+function groupDesignEigenModes(sourceModes = []) {
+  const modes = sourceModes
+    .map((mode, index) => ({
+      mode,
+      index,
+      re: Number(mode?.re),
+      im: Number(mode?.im),
+      runCaseIndex: Number.isInteger(mode?.runCaseIndex) ? Number(mode.runCaseIndex) : -1,
+    }))
+    .filter((entry) => Number.isFinite(entry.re) && Number.isFinite(entry.im));
+  const used = new Set();
+  const groups = [];
+  modes.forEach((entry) => {
+    if (used.has(entry.index)) return;
+    used.add(entry.index);
+    const absIm = Math.abs(entry.im);
+    const groupEntries = [entry];
+    if (absIm > 1e-4) {
+      let best = null;
+      modes.forEach((candidate) => {
+        if (used.has(candidate.index)) return;
+        if (candidate.index === entry.index) return;
+        if (entry.runCaseIndex !== candidate.runCaseIndex) return;
+        if (entry.im * candidate.im >= 0) return;
+        const reScale = Math.max(1e-6, Math.abs(entry.re), Math.abs(candidate.re));
+        const imScale = Math.max(1e-6, absIm, Math.abs(candidate.im));
+        const reErr = Math.abs(entry.re - candidate.re) / reScale;
+        const imErr = Math.abs(entry.im + candidate.im) / imScale;
+        const score = reErr + imErr;
+        if (reErr <= 0.03 && imErr <= 0.03 && (!best || score < best.score)) {
+          best = { candidate, score };
+        }
+      });
+      if (best) {
+        used.add(best.candidate.index);
+        groupEntries.push(best.candidate);
+      }
+    }
+    const representative = groupEntries
+      .slice()
+      .sort((a, b) => Math.abs(b.im) - Math.abs(a.im) || b.im - a.im || a.index - b.index)[0];
+    groups.push({
+      id: groups.length,
+      entries: groupEntries,
+      indices: groupEntries.map((item) => item.index),
+      representativeIndex: representative.index,
+      re: groupEntries.reduce((sum, item) => sum + item.re, 0) / groupEntries.length,
+      im: representative.im,
+      absIm: Math.max(...groupEntries.map((item) => Math.abs(item.im))),
+      mode: representative.mode,
+      features: designEigenModeFeatures(representative.mode),
+    });
+  });
+  return groups;
+}
+
+function assignDesignEigenGroups(groups = []) {
+  const classBits = new Map(DESIGN_EIGEN_ASSIGNABLE_CLASSES.map((key, idx) => [key, 1 << idx]));
+  const candidateLists = groups.map((group) => {
+    const candidates = DESIGN_EIGEN_ASSIGNABLE_CLASSES
+      .map((key) => {
+        const score = designEigenScoreForClass(group.features, key);
+        return {
+          classKey: key,
+          classLabel: (DESIGN_EIGEN_TARGETS[key] || DESIGN_EIGEN_TARGETS.unknown).label,
+          confidence: score,
+        };
+      })
+      .filter((entry) => entry.confidence >= DESIGN_EIGEN_CLASS_SCORE_MIN)
+      .sort((a, b) => b.confidence - a.confidence);
+    candidates.push({ classKey: 'unknown', classLabel: 'Unclassified', confidence: 0 });
+    return candidates;
+  });
+  const memo = new Map();
+  const solve = (groupIdx, usedMask) => {
+    if (groupIdx >= groups.length) return { score: 0, choices: [] };
+    const key = `${groupIdx}:${usedMask}`;
+    if (memo.has(key)) return memo.get(key);
+    let best = { score: -Infinity, choices: [] };
+    candidateLists[groupIdx].forEach((candidate) => {
+      const bit = classBits.get(candidate.classKey) || 0;
+      if (bit && (usedMask & bit)) return;
+      const rest = solve(groupIdx + 1, usedMask | bit);
+      const bonus = candidate.classKey === 'unknown' ? 0 : 0.02;
+      const score = Number(candidate.confidence) + bonus + Number(rest.score || 0);
+      if (score > best.score) {
+        best = { score, choices: [candidate, ...rest.choices] };
+      }
+    });
+    memo.set(key, best);
+    return best;
+  };
+  return solve(0, 0).choices;
+}
+
+function summarizeDesignEigenModes(modes = []) {
+  const sourceModes = Array.isArray(modes) ? modes : [];
+  const groups = groupDesignEigenModes(sourceModes);
+  const assignments = assignDesignEigenGroups(groups);
+  const assignedByGroup = new Map(groups.map((group, idx) => [group.id, assignments[idx] || {
+    classKey: 'unknown',
+    classLabel: 'Unclassified',
+    confidence: 0,
+  }]));
+  const modeAssignments = new Map();
+  groups.forEach((group) => {
+    const assignment = assignedByGroup.get(group.id) || { classKey: 'unknown', classLabel: 'Unclassified', confidence: 0 };
+    group.entries.forEach((entry) => {
+      modeAssignments.set(entry.index, {
+        ...assignment,
+        groupId: group.id,
+        representativeIndex: group.representativeIndex,
+        labelVisible: assignment.classKey !== 'unknown'
+          && (group.entries.length > 1 || entry.index === group.representativeIndex),
+      });
+    });
+  });
+  const classifiedModes = sourceModes
+    .map((mode, index) => {
+      const re = Number(mode?.re);
+      const im = Number(mode?.im);
+      if (!Number.isFinite(re) || !Number.isFinite(im)) return null;
+      const assignment = modeAssignments.get(index) || {
+        classKey: 'unknown',
+        classLabel: 'Unclassified',
+        confidence: 0,
+        groupId: -1,
+        representativeIndex: index,
+        labelVisible: false,
+      };
+      const features = designEigenModeFeatures(mode);
+      return {
+        ...mode,
+        index,
+        re,
+        im,
+        classKey: assignment.classKey,
+        classLabel: assignment.classLabel,
+        classConfidence: assignment.confidence,
+        groupId: assignment.groupId,
+        representativeIndex: assignment.representativeIndex,
+        labelVisible: Boolean(assignment.labelVisible),
+        participation: {
+          longitudinal: features.longitudinal,
+          lateral: features.lateral,
+          pitch: features.pitch,
+          surge: features.surge,
+          roll: features.roll,
+          yaw: features.yaw,
+        },
+      };
+    })
+    .filter(Boolean);
+  const byClass = {};
+  groups.forEach((group) => {
+    const assignment = assignedByGroup.get(group.id);
+    if (!assignment || assignment.classKey === 'unknown') return;
+    const key = assignment.classKey;
+    const worstRe = Math.max(...group.entries.map((entry) => entry.re));
+    const worstEntry = group.entries.reduce((best, entry) => (!best || entry.re > best.re ? entry : best), null);
+    const existing = byClass[key];
+    if (!existing || worstRe > Number(existing.worstReal)) {
+      const oscillation = designEigenOscillationMetrics(worstRe, group.im);
+      const target = DESIGN_EIGEN_TARGETS[key] || DESIGN_EIGEN_TARGETS.unknown;
+      const qualityComponents = designEigenQualityComponents(oscillation, target);
+      byClass[key] = {
+        key,
+        label: assignment.classLabel || (DESIGN_EIGEN_TARGETS[key]?.label || 'Unknown mode'),
+        worstReal: Number(worstRe),
+        worstImag: Number(group.im),
+        dampingRatio: oscillation.dampingRatio,
+        realAxisRatio: oscillation.realAxisRatio,
+        naturalFrequency: oscillation.naturalFrequency,
+        period: oscillation.period,
+        halfLife: oscillation.halfLife,
+        cyclesToHalf: oscillation.cyclesToHalf,
+        qualityPenalty: qualityComponents.total,
+        qualityComponents,
+        modeIndex: Number(worstEntry?.index),
+        groupId: group.id,
+        confidence: Number(assignment.confidence) || 0,
+      };
+    }
+  });
+  const worst = classifiedModes.reduce((best, mode) => {
+    if (!best || Number(mode.re) > Number(best.re)) return mode;
+    return best;
+  }, null);
+  const classRows = Object.values(byClass)
+    .sort((a, b) => {
+      const ai = DESIGN_EIGEN_CLASS_ORDER.indexOf(a.key);
+      const bi = DESIGN_EIGEN_CLASS_ORDER.indexOf(b.key);
+      const ao = ai >= 0 ? ai : 999;
+      const bo = bi >= 0 ? bi : 999;
+      return ao - bo || Number(a.modeIndex) - Number(b.modeIndex);
+    });
+  const qualityRows = classRows.filter((row) => Number(row.qualityPenalty) > 0);
+  const worstQuality = qualityRows.reduce((best, row) => (!best || Number(row.qualityPenalty) > Number(best.qualityPenalty) ? row : best), null);
+  return {
+    modes: classifiedModes,
+    classRows,
+    groups: groups.map((group) => {
+      const assignment = assignedByGroup.get(group.id) || {};
+      return {
+        id: group.id,
+        indices: group.indices.slice(),
+        representativeIndex: group.representativeIndex,
+        re: group.re,
+        im: group.im,
+        absIm: group.absIm,
+        classKey: assignment.classKey || 'unknown',
+        classLabel: assignment.classLabel || 'Unclassified',
+        confidence: Number(assignment.confidence) || 0,
+      };
+    }),
+    modeCount: classifiedModes.length,
+    worstReal: worst ? Number(worst.re) : Number.NaN,
+    worstImag: worst ? Number(worst.im) : Number.NaN,
+    worstLabel: worst ? (worst.classKey === 'unknown' ? 'unclassified' : (worst.classLabel || '')) : '',
+    worstClassKey: worst?.classKey || '',
+    worstModeIndex: worst ? Number(worst.index) : -1,
+    unstableCount: classifiedModes.filter((mode) => Number(mode.re) > 0).length,
+    qualityPenalty: qualityRows.reduce((sum, row) => sum + (Number(row.qualityPenalty) || 0), 0),
+    worstQualityLabel: worstQuality?.label || '',
+    worstQualityClassKey: worstQuality?.key || '',
+    worstQualityPenalty: Number(worstQuality?.qualityPenalty) || 0,
+    worstQualityDampingRatio: finiteNumber(worstQuality?.dampingRatio),
+    worstQualityRealAxisRatio: finiteNumber(worstQuality?.realAxisRatio),
+    worstQualityCyclesToHalf: finiteNumber(worstQuality?.cyclesToHalf),
+    worstQualityComponents: worstQuality?.qualityComponents ? { ...worstQuality.qualityComponents } : null,
+  };
+}
+
 
 function computeModelCounts(model) {
   if (!model?.surfaces?.length) return { surfaces: 0, strips: 0, vortices: 0 };
@@ -1923,6 +2548,17 @@ function initTopNav() {
   });
 }
 
+
+
+
+
+
+
+
+
+
+
+
 function initPanelCollapse() {
   const panels = document.querySelectorAll('.panel');
   panels.forEach((panel, idx) => {
@@ -2019,6 +2655,12 @@ function applyYDuplicate(model) {
   model.surfaces = next;
   return model;
 }
+
+
+
+
+
+
 
 function ensureExecWorker() {
   if (execWorker) return execWorker;
@@ -2907,10 +3549,6 @@ function renderMassProps(props = null) {
   show(els.massIxy, mp.ixy, 4);
   show(els.massIxz, mp.ixz, 4);
   show(els.massIyz, mp.iyz, 4);
-  if (els.massPropsMeta) {
-    const name = ensureMassFileExtension(uiState.massPropsFilename || 'model.mass');
-    els.massPropsMeta.textContent = `Loaded file: ${name}`;
-  }
 }
 
 function parseMassFileText(text) {
@@ -3300,22 +3938,25 @@ function applyRunCaseToUI(entry) {
     }
     return false;
   };
-  const nextMassProps = { ...(uiState.massProps || readMassPropsFromUI() || makeDefaultMassProps()) };
-  let massChanged = false;
-  massChanged = updateMassProp(nextMassProps, 'mass', inputs.mass) || massChanged;
-  massChanged = updateMassProp(nextMassProps, 'xcg', inputs.xcg) || massChanged;
-  massChanged = updateMassProp(nextMassProps, 'ycg', inputs.ycg) || massChanged;
-  massChanged = updateMassProp(nextMassProps, 'zcg', inputs.zcg) || massChanged;
-  massChanged = updateMassProp(nextMassProps, 'ixx', inputs.ixx) || massChanged;
-  massChanged = updateMassProp(nextMassProps, 'iyy', inputs.iyy) || massChanged;
-  massChanged = updateMassProp(nextMassProps, 'izz', inputs.izz) || massChanged;
-  massChanged = updateMassProp(nextMassProps, 'ixy', inputs.ixy) || massChanged;
-  massChanged = updateMassProp(nextMassProps, 'iyz', inputs.iyz) || massChanged;
-  massChanged = updateMassProp(nextMassProps, 'ixz', inputs.ixz) || massChanged;
-  massChanged = updateMassProp(nextMassProps, 'ixz', inputs.izx) || massChanged;
-  if (massChanged) {
-    uiState.massProps = nextMassProps;
-    renderMassProps(nextMassProps);
+  if (false) {
+  } else {
+    const nextMassProps = { ...(uiState.massProps || readMassPropsFromUI() || makeDefaultMassProps()) };
+    let massChanged = false;
+    massChanged = updateMassProp(nextMassProps, 'mass', inputs.mass) || massChanged;
+    massChanged = updateMassProp(nextMassProps, 'xcg', inputs.xcg) || massChanged;
+    massChanged = updateMassProp(nextMassProps, 'ycg', inputs.ycg) || massChanged;
+    massChanged = updateMassProp(nextMassProps, 'zcg', inputs.zcg) || massChanged;
+    massChanged = updateMassProp(nextMassProps, 'ixx', inputs.ixx) || massChanged;
+    massChanged = updateMassProp(nextMassProps, 'iyy', inputs.iyy) || massChanged;
+    massChanged = updateMassProp(nextMassProps, 'izz', inputs.izz) || massChanged;
+    massChanged = updateMassProp(nextMassProps, 'ixy', inputs.ixy) || massChanged;
+    massChanged = updateMassProp(nextMassProps, 'iyz', inputs.iyz) || massChanged;
+    massChanged = updateMassProp(nextMassProps, 'ixz', inputs.ixz) || massChanged;
+    massChanged = updateMassProp(nextMassProps, 'ixz', inputs.izx) || massChanged;
+    if (massChanged) {
+      uiState.massProps = nextMassProps;
+      renderMassProps(nextMassProps);
+    }
   }
 
   const byVar = new Map();
@@ -3581,6 +4222,7 @@ function applyLoadedMassProps(props, filename, source = 'Loaded', { applyToActiv
     renderFileHighlight();
     syncFileEditorScroll();
   }
+  if (els.massPropsMeta) els.massPropsMeta.textContent = `Loaded file: ${ensureMassFileExtension(filename)}`;
   rebuildMassPointOverlay(viewerState.bounds || null);
   logDebug(`${source} mass file: ${filename}`);
 }
@@ -4183,7 +4825,8 @@ async function loadDefaultAVL() {
 }
 
 async function loadDefaultRunAndMass() {
-  const defaultBases = ['supra', 'plane'];
+  const currentBase = basenamePath(String(uiState.filename || '')).replace(/\.[^.]+$/, '').toLowerCase();
+  const defaultBases = currentBase ? [currentBase] : ['supra', 'plane'];
   for (const base of defaultBases) {
     const massName = `${base}.mass`;
     const massCandidates = [
@@ -4218,6 +4861,10 @@ async function loadDefaultRunAndMass() {
       return;
     }
   }
+  resetMassSessionDefaults();
+  resetRunCaseSessionDefaults();
+  uiState.seedNoRunFlightFromExec = false;
+  if (currentBase) logDebug(`No default companion run/mass for ${currentBase}; using session defaults.`);
 }
 
 async function fetchTextFromCandidates(candidates) {
@@ -4518,6 +5165,22 @@ els.massPropsInput?.addEventListener('change', async (evt) => {
 els.massPropsSaveBtn?.addEventListener('click', () => {
   const filename = ensureMassFileExtension(uiState.massPropsFilename || 'model.mass');
   uiState.massPropsFilename = filename;
+  if (false) {
+    const props = uiState.massProps || readMassPropsFromUI();
+    uiState.massFileProps = { ...props };
+    uiState.massFileText = serializeMassFile(props);
+    renderMassFileProps(uiState.massFileProps);
+    updateEditorTabLabels();
+    if (els.massPropsMeta) els.massPropsMeta.textContent = `Saved file: ${filename}`;
+    downloadText(filename, uiState.massFileText);
+    if (uiState.editorTab === 'mass' && els.fileText) {
+      els.fileText.value = getEditorTabText('mass');
+      fitFileEditorFontSize();
+      renderFileHighlight();
+      syncFileEditorScroll();
+    }
+    return;
+  }
   const sourceText = (() => {
     if (uiState.editorTab === 'mass' && els.fileText) return String(els.fileText.value || '');
     return String(uiState.massFileText || '');
@@ -4533,6 +5196,7 @@ els.massPropsSaveBtn?.addEventListener('click', () => {
   }
   updateEditorTabLabels();
   downloadText(filename, uiState.massFileText);
+  if (els.massPropsMeta) els.massPropsMeta.textContent = `Saved file: ${filename}`;
   if (uiState.editorTab === 'mass' && els.fileText) {
     els.fileText.value = getEditorTabText('mass');
     fitFileEditorFontSize();
@@ -4567,6 +5231,7 @@ els.editorTabRun?.addEventListener('click', () => applyEditorTab('run'));
 ].forEach((el) => {
   if (!el) return;
   el.addEventListener('input', () => {
+    if (false) return;
     uiState.massProps = readMassPropsFromUI();
     if (el === els.massTotal && els.mass) {
       const next = Number(els.massTotal.value);
@@ -4585,6 +5250,10 @@ els.editorTabRun?.addEventListener('click', () => applyEditorTab('run'));
     }
   });
   el.addEventListener('change', () => {
+    if (false) {
+      renderMassProps(uiState.massProps);
+      return;
+    }
     uiState.massProps = readMassPropsFromUI();
     renderMassProps(uiState.massProps);
     if (el === els.massTotal) {
@@ -4606,6 +5275,7 @@ els.editorTabRun?.addEventListener('click', () => applyEditorTab('run'));
 ].forEach(([el, key, mirror]) => {
   if (!el) return;
   el.addEventListener('input', () => {
+    if (false) return;
     const next = Number(el.value);
     if (!Number.isFinite(next)) return;
     const props = { ...(uiState.massProps || readMassPropsFromUI()) };
@@ -4616,6 +5286,10 @@ els.editorTabRun?.addEventListener('click', () => applyEditorTab('run'));
     }
   });
   el.addEventListener('change', () => {
+    if (false) {
+      renderMassProps(uiState.massProps);
+      return;
+    }
     const next = Number(el.value);
     if (!Number.isFinite(next)) {
       renderMassProps(uiState.massProps || readMassPropsFromUI());
@@ -4670,6 +5344,12 @@ els.eigenZoomOut?.addEventListener('click', () => {
 });
 els.eigenPan?.addEventListener('click', () => {
   setEigenPanMode(!uiState.eigenPanMode);
+});
+els.eigenScaleLock?.addEventListener('click', () => {
+  setEigenScaleLocked(!uiState.eigenScaleLocked);
+});
+els.eigenDivergence?.addEventListener('click', () => {
+  setEigenDivergenceMode(!uiState.eigenShowDivergence);
 });
 els.eigenDownload?.addEventListener('click', () => {
   const rows = buildEigenmodeRows();
@@ -4759,6 +5439,7 @@ els.trefftz?.addEventListener('pointermove', handleTrefftzPointerMove);
 els.trefftz?.addEventListener('pointerdown', handleTrefftzPointerMove);
 els.trefftz?.addEventListener('pointerleave', handleTrefftzPointerLeave);
 els.eigenPlot?.addEventListener('click', handleEigenCanvasClick);
+els.eigenPlot?.addEventListener('dblclick', handleEigenCanvasDoubleClick);
 els.eigenPlot?.addEventListener('pointerdown', handleEigenPointerDown);
 els.eigenPlot?.addEventListener('pointermove', handleEigenPointerMove);
 els.eigenPlot?.addEventListener('pointerup', handleEigenPointerUp);
@@ -4801,6 +5482,10 @@ els.gee?.addEventListener('input', () => {
   requestAutoUpdate(AUTO_UPDATE_STAGE.CONSTRAINTS | AUTO_UPDATE_STAGE.EXEC | AUTO_UPDATE_STAGE.EIGEN);
 });
 els.mass?.addEventListener('input', () => {
+  if (false) {
+    renderMassProps(uiState.massProps);
+    return;
+  }
   const next = Number(els.mass.value);
   if (Number.isFinite(next)) {
     if (els.massTotal && document.activeElement !== els.massTotal) {
@@ -5172,6 +5857,31 @@ function handleTrefftzPointerLeave(evt) {
   trefftzHoverState.yPx = null;
   if (uiState.trefftzData?.strips?.length) {
     updateTrefftz(uiState.lastCL ?? Number(els.cl?.value || 0));
+  }
+}
+
+function drawCanvasRoundRect(ctx, x, y, w, h, r) {
+  const radius = Math.max(0, Math.min(Number(r) || 0, Math.abs(w) / 2, Math.abs(h) / 2));
+  ctx.beginPath();
+  ctx.moveTo(x + radius, y);
+  ctx.lineTo(x + w - radius, y);
+  ctx.quadraticCurveTo(x + w, y, x + w, y + radius);
+  ctx.lineTo(x + w, y + h - radius);
+  ctx.quadraticCurveTo(x + w, y + h, x + w - radius, y + h);
+  ctx.lineTo(x + radius, y + h);
+  ctx.quadraticCurveTo(x, y + h, x, y + h - radius);
+  ctx.lineTo(x, y + radius);
+  ctx.quadraticCurveTo(x, y, x + radius, y);
+  ctx.closePath();
+}
+
+function trefftzHoverDisplayLabel(series) {
+  switch (series) {
+    case 'clp': return 'Cl perp';
+    case 'cl': return 'Cl';
+    case 'cnc': return 'Cl*c/Cref';
+    case 'ai': return 'ai';
+    default: return String(series || '').trim() || 'value';
   }
 }
 
@@ -5631,6 +6341,7 @@ function updateTrefftz(cl) {
     const seriesDefs = [
       {
         id: 'clp',
+        label: 'cl_perp',
         color: '#ef4444',
         dash: [6, 4],
         valueOf: (entry) => Number(entry?.[4]),
@@ -5638,6 +6349,7 @@ function updateTrefftz(cl) {
       },
       {
         id: 'cl',
+        label: 'cl',
         color: '#fb923c',
         dash: [6, 3, 1.5, 3],
         valueOf: (entry) => Number(entry?.[3]),
@@ -5645,6 +6357,7 @@ function updateTrefftz(cl) {
       },
       {
         id: 'cnc',
+        label: 'cl*c/cref',
         color: '#22c55e',
         dash: [],
         valueOf: (entry) => Number(entry?.[2]) / crefSafe,
@@ -5652,6 +6365,7 @@ function updateTrefftz(cl) {
       },
       {
         id: 'ai',
+        label: 'ai',
         color: '#3b82f6',
         dash: [1.5, 3],
         valueOf: (entry) => -Number(entry?.[5]),
@@ -5744,6 +6458,7 @@ function updateTrefftz(cl) {
           if (!Number.isFinite(yPx) || yPx < (y0 - 2) || yPx > (y1 + 2)) return;
           markers.push({
             series: series.id,
+            seriesLabel: series.label,
             color: series.color,
             x: hoverX,
             y: yPx,
@@ -5772,9 +6487,51 @@ function updateTrefftz(cl) {
       const sortedMarkers = markers
         .filter((marker) => Number.isFinite(marker.value))
         .sort((a, b) => a.y - b.y);
-      ctx.font = '11px Consolas, "Courier New", monospace';
+      ctx.font = '12px Consolas, "Courier New", monospace';
       ctx.textBaseline = 'middle';
-      let prevLabelY = -Infinity;
+      const labelFont = ctx.font;
+      const labelHeight = 20;
+      const labelRadius = 6;
+      const labelPadLeft = 20;
+      const labelPadRight = 7;
+      const labelGap = 9;
+      const labelMinGap = 4;
+      const labelTopLimit = y0 + labelHeight / 2 + 4;
+      const labelBottomLimit = y1 - labelHeight / 2 - 4;
+      const labelItems = sortedMarkers.map((marker) => {
+        const valueText = fmt(marker.value, 3);
+        const displayLabel = trefftzHoverDisplayLabel(marker.series);
+        const labelText = `${displayLabel} ${valueText}`;
+        const labelW = Math.ceil(ctx.measureText(labelText).width + labelPadLeft + labelPadRight);
+        const preferRight = (marker.x + labelGap + labelW) <= (x1 - 4);
+        const unclampedBoxX = preferRight ? (marker.x + labelGap) : (marker.x - labelGap - labelW);
+        const boxX = clampNumber(unclampedBoxX, x0 + 4, Math.max(x0 + 4, x1 - labelW - 4));
+        return {
+          marker,
+          valueText,
+          displayLabel,
+          labelText,
+          labelW,
+          boxX,
+          labelY: clampNumber(marker.y, labelTopLimit, labelBottomLimit),
+        };
+      });
+      for (let i = 1; i < labelItems.length; i += 1) {
+        labelItems[i].labelY = Math.max(labelItems[i].labelY, labelItems[i - 1].labelY + labelHeight + labelMinGap);
+      }
+      if (labelItems.length) {
+        const overflow = labelItems[labelItems.length - 1].labelY - labelBottomLimit;
+        if (overflow > 0) {
+          labelItems[labelItems.length - 1].labelY = labelBottomLimit;
+          for (let i = labelItems.length - 2; i >= 0; i -= 1) {
+            labelItems[i].labelY = Math.min(labelItems[i].labelY, labelItems[i + 1].labelY - labelHeight - labelMinGap);
+          }
+          for (let i = 0; i < labelItems.length; i += 1) {
+            labelItems[i].labelY = Math.max(labelTopLimit, labelItems[i].labelY);
+            if (i > 0) labelItems[i].labelY = Math.max(labelItems[i].labelY, labelItems[i - 1].labelY + labelHeight + labelMinGap);
+          }
+        }
+      }
       sortedMarkers.forEach((marker) => {
         ctx.beginPath();
         ctx.fillStyle = marker.color;
@@ -5783,19 +6540,40 @@ function updateTrefftz(cl) {
         ctx.strokeStyle = 'rgba(8, 10, 12, 0.92)';
         ctx.lineWidth = 1.1;
         ctx.stroke();
-        const labelText = fmt(marker.value, 3);
-        const labelW = ctx.measureText(labelText).width;
-        const preferRight = (marker.x + 8 + labelW) <= (x1 - 4);
-        ctx.textAlign = preferRight ? 'left' : 'right';
-        let labelY = Math.max(y0 + 6, Math.min(y1 - 6, marker.y));
-        if (labelY < prevLabelY + 11) labelY = Math.min(y1 - 6, prevLabelY + 11);
-        prevLabelY = labelY;
-        const labelX = preferRight ? (marker.x + 8) : (marker.x - 8);
-        ctx.lineWidth = 2.2;
-        ctx.strokeStyle = 'rgba(8, 10, 12, 0.92)';
-        ctx.strokeText(labelText, labelX, labelY);
+      });
+      labelItems.forEach((item) => {
+        const marker = item.marker;
+        const boxY = item.labelY - labelHeight / 2;
+        const boxX = item.boxX;
+        const boxW = item.labelW;
+        ctx.save();
+        ctx.globalAlpha = 0.58;
+        ctx.strokeStyle = marker.color;
+        ctx.lineWidth = 1;
+        ctx.beginPath();
+        const leaderTargetX = boxX > marker.x ? boxX : boxX + boxW;
+        ctx.moveTo(marker.x, marker.y);
+        ctx.lineTo(leaderTargetX, item.labelY);
+        ctx.stroke();
+        ctx.restore();
+
+        ctx.save();
+        drawCanvasRoundRect(ctx, boxX, boxY, boxW, labelHeight, labelRadius);
+        ctx.fillStyle = 'rgba(3, 7, 18, 0.88)';
+        ctx.fill();
+        ctx.strokeStyle = 'rgba(148, 163, 184, 0.30)';
+        ctx.lineWidth = 1;
+        ctx.stroke();
+        ctx.beginPath();
         ctx.fillStyle = marker.color;
-        ctx.fillText(labelText, labelX, labelY);
+        ctx.arc(boxX + 9, item.labelY, 3, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.font = labelFont;
+        ctx.textAlign = 'left';
+        ctx.textBaseline = 'middle';
+        ctx.fillStyle = '#e2e8f0';
+        ctx.fillText(item.labelText, boxX + labelPadLeft, item.labelY);
+        ctx.restore();
       });
       hoverInfo = {
         active: true,
@@ -5805,12 +6583,26 @@ function updateTrefftz(cl) {
         spanLabelY,
         markerCount: sortedMarkers.length,
         markers: sortedMarkers.map((marker) => ({
+          ...(() => {
+            const item = labelItems.find((candidate) => candidate.marker === marker);
+            return item ? {
+              displayLabel: item.displayLabel,
+              labelBox: {
+                x: item.boxX,
+                y: item.labelY - labelHeight / 2,
+                width: item.labelW,
+                height: labelHeight,
+              },
+            } : {};
+          })(),
           series: marker.series,
+          seriesLabel: marker.seriesLabel,
           color: marker.color,
           x: marker.x,
           y: marker.y,
           value: marker.value,
-          label: fmt(marker.value, 3),
+          valueLabel: fmt(marker.value, 3),
+          label: `${marker.seriesLabel || marker.series} ${fmt(marker.value, 3)}`,
           surfaceIndex: marker.surfaceIndex,
         })),
       };
@@ -5893,14 +6685,56 @@ if (typeof window !== 'undefined') {
     getEigenPanMode() {
       return Boolean(uiState.eigenPanMode);
     },
+    getEigenScaleLocked() {
+      return Boolean(uiState.eigenScaleLocked);
+    },
+    getEigenDivergenceMode() {
+      return Boolean(uiState.eigenShowDivergence);
+    },
     getEigenPoints() {
       return Array.isArray(uiState.eigenPoints) ? uiState.eigenPoints.map((p) => ({ ...p })) : [];
     },
     getEigenViewport() {
       return uiState.eigenViewport ? { ...uiState.eigenViewport } : null;
     },
+    getEigenPlotRenderState() {
+      return uiState.eigenPlotRenderState ? JSON.parse(JSON.stringify(uiState.eigenPlotRenderState)) : null;
+    },
     getEigenStatusMessage() {
       return String(uiState.eigenStatusMessage || '');
+    },
+    startEigenModeAnimationForTest(index = 0) {
+      startModeAnimation(Number(index) || 0);
+      return window.__trefftzTestHook.getModeAnimationState();
+    },
+    setEigenDivergenceModeForTest(enabled) {
+      setEigenDivergenceMode(Boolean(enabled));
+      return window.__trefftzTestHook.getEigenDivergenceMode();
+    },
+    setModeAnimationElapsedForTest(seconds = 0) {
+      if (modeAnimation) {
+        modeAnimation.started = performance.now() - Math.max(0, Number(seconds) || 0) * 1000;
+        updateModeAnimation();
+      }
+      return window.__trefftzTestHook.getModeAnimationState();
+    },
+    getModeAnimationState() {
+      if (!modeAnimation) return null;
+      return {
+        sigma: Number(modeAnimation.sigma),
+        rawReal: Number(modeAnimation.rawReal),
+        showDivergence: Boolean(modeAnimation.showDivergence),
+        initialAmplitude: Number(modeAnimation.initialAmplitude),
+        amplitude: Number(modeAnimation.lastAmplitude),
+        rawAmplitude: Number(modeAnimation.lastRawAmplitude),
+        amplitudeCap: Number(modeAnimation.amplitudeCap),
+        positionError: Number(modeAnimation.positionError),
+        resetPositionError: Number(modeAnimation.resetPositionError),
+        referenceSpan: Number(modeAnimation.referenceSpan),
+        loopCount: Number(modeAnimation.loopCount),
+        elapsed: Number(modeAnimation.elapsed),
+        selectedMode: Number(uiState.selectedEigenMode),
+      };
     },
     getRunCases() {
       return Array.isArray(uiState.runCases)
@@ -6204,16 +7038,44 @@ if (typeof window !== 'undefined') {
       let labelCount = 0;
       let labelMinWidth = Infinity;
       let labelMaxWidth = 0;
+      let labelMinHeight = Infinity;
+      let labelMaxHeight = 0;
       let labelMaxChord = 0;
       let labelMinWidthToChord = Infinity;
       let labelMaxWidthToChord = 0;
+      let labelMaxHeightToReferenceSize = 0;
       let labelVisibleCount = 0;
       let labelClipFailures = 0;
       let labelMaxOverflowPx = 0;
       let labelMaxTextLength = 0;
+      let skinMeshCount = 0;
+      let skinMeshVisible = 0;
+      let skinMaterialMinEmissiveIntensity = Infinity;
+      let skinMaterialMinEmissiveLuma = Infinity;
+      const skinMaterials = [];
       const labels = [];
       if (aircraft) {
         aircraft.traverse((obj) => {
+          if (obj?.isMesh && obj.name === 'surface-skin') {
+            skinMeshCount += 1;
+            if (obj.visible) skinMeshVisible += 1;
+            const mat = obj.material || {};
+            const intensity = Number(mat.emissiveIntensity);
+            const emissive = mat.emissive;
+            const luma = emissive
+              ? (0.2126 * Number(emissive.r || 0)) + (0.7152 * Number(emissive.g || 0)) + (0.0722 * Number(emissive.b || 0))
+              : 0;
+            if (Number.isFinite(intensity)) skinMaterialMinEmissiveIntensity = Math.min(skinMaterialMinEmissiveIntensity, intensity);
+            if (Number.isFinite(luma)) skinMaterialMinEmissiveLuma = Math.min(skinMaterialMinEmissiveLuma, luma);
+            skinMaterials.push({
+              name: String(obj.parent?.userData?.surfaceName || obj.name || ''),
+              colorHex: mat.color ? `#${mat.color.getHexString()}` : null,
+              emissiveHex: emissive ? `#${emissive.getHexString()}` : null,
+              emissiveIntensity: Number.isFinite(intensity) ? intensity : null,
+              emissiveLuma: Number.isFinite(luma) ? luma : null,
+              side: Number.isFinite(Number(mat.side)) ? Number(mat.side) : null,
+            });
+          }
           if (obj?.isLine && obj.name === 'surface-airfoil-outline') {
             airfoilOutlineCount += 1;
             if (obj.visible) airfoilOutlineVisible += 1;
@@ -6260,11 +7122,17 @@ if (typeof window !== 'undefined') {
           if (obj?.isSprite && obj?.userData?.surfaceLabel) {
             labelCount += 1;
             const w = Number(obj.scale?.x);
+            const h = Number(obj.scale?.y);
             const chord = Number(obj.userData?.chordWorld);
+            const labelReferenceSize = Number(obj.userData?.labelReferenceSize);
             if (obj.visible) labelVisibleCount += 1;
             if (Number.isFinite(w)) {
               if (w < labelMinWidth) labelMinWidth = w;
               if (w > labelMaxWidth) labelMaxWidth = w;
+            }
+            if (Number.isFinite(h)) {
+              if (h < labelMinHeight) labelMinHeight = h;
+              if (h > labelMaxHeight) labelMaxHeight = h;
             }
             if (Number.isFinite(chord) && chord > 1e-9) {
               if (chord > labelMaxChord) labelMaxChord = chord;
@@ -6273,6 +7141,10 @@ if (typeof window !== 'undefined') {
                 if (ratio < labelMinWidthToChord) labelMinWidthToChord = ratio;
                 if (ratio > labelMaxWidthToChord) labelMaxWidthToChord = ratio;
               }
+            }
+            if (Number.isFinite(h) && Number.isFinite(labelReferenceSize) && labelReferenceSize > 1e-9) {
+              const ratio = h / labelReferenceSize;
+              if (Number.isFinite(ratio) && ratio > labelMaxHeightToReferenceSize) labelMaxHeightToReferenceSize = ratio;
             }
             const text = String(obj.userData?.labelText ?? '');
             if (text.length > labelMaxTextLength) labelMaxTextLength = text.length;
@@ -6302,6 +7174,9 @@ if (typeof window !== 'undefined') {
               canvasHeightPx: Number.isFinite(canvasHeightPx) ? canvasHeightPx : null,
               textWidthPx: Number.isFinite(textWidthPx) ? textWidthPx : null,
               paddingXPx: Number.isFinite(paddingXPx) ? paddingXPx : null,
+              worldWidth: Number.isFinite(w) ? w : null,
+              worldHeight: Number.isFinite(h) ? h : null,
+              referenceSize: Number.isFinite(labelReferenceSize) ? labelReferenceSize : null,
               labelFits: explicitFit !== false,
               overflowPx: Number.isFinite(overflowPx) ? overflowPx : null,
             });
@@ -6323,9 +7198,17 @@ if (typeof window !== 'undefined') {
         labelMaxTextLength,
         labelMinWidth: Number.isFinite(labelMinWidth) ? labelMinWidth : 0,
         labelMaxWidth,
+        labelMinHeight: Number.isFinite(labelMinHeight) ? labelMinHeight : 0,
+        labelMaxHeight,
         labelMaxChord,
         labelMinWidthToChord: Number.isFinite(labelMinWidthToChord) ? labelMinWidthToChord : 0,
         labelMaxWidthToChord,
+        labelMaxHeightToReferenceSize,
+        skinMeshCount,
+        skinMeshVisible,
+        skinMaterialMinEmissiveIntensity: Number.isFinite(skinMaterialMinEmissiveIntensity) ? skinMaterialMinEmissiveIntensity : 0,
+        skinMaterialMinEmissiveLuma: Number.isFinite(skinMaterialMinEmissiveLuma) ? skinMaterialMinEmissiveLuma : 0,
+        skinMaterials,
         labels,
       };
     },
@@ -6821,6 +7704,26 @@ if (typeof window !== 'undefined') {
         z: Number(marker.position?.z) || 0,
       };
     },
+    getReferenceMarkerVisualState() {
+      if (!aircraft) return null;
+      const marker = aircraft.getObjectByName?.('reference-marker');
+      if (!marker) return null;
+      marker.updateMatrixWorld?.(true);
+      const pos = marker.getWorldPosition
+        ? marker.getWorldPosition(new THREE.Vector3())
+        : { x: Number(marker.position?.x) || 0, y: Number(marker.position?.y) || 0, z: Number(marker.position?.z) || 0 };
+      const radius = Number(marker.userData?.radius);
+      const referenceSize = Number(marker.userData?.referenceSize);
+      const bounds = viewerState.bounds || computeBounds(aircraft);
+      return {
+        x: Number(pos.x) || 0,
+        y: Number(pos.y) || 0,
+        z: Number(pos.z) || 0,
+        radius: Number.isFinite(radius) ? radius : null,
+        referenceSize: Number.isFinite(referenceSize) ? referenceSize : null,
+        boundsMaxDim: Number.isFinite(Number(bounds?.maxDim)) ? Number(bounds.maxDim) : null,
+      };
+    },
     sampleInducedAtWorld(x = 0, y = 0, z = 0) {
       const px = Number(x);
       const py = Number(y);
@@ -6857,14 +7760,16 @@ if (typeof window !== 'undefined') {
 
 function computeEigenModesFromExec(result) {
   if (result?.EIGEN?.modes?.length) {
-    return result.EIGEN.modes.map((m) => ({
-      name: m.name || 'Mode',
-      re: Number(m.re) || 0,
-      im: Number(m.im) || 0,
-      vec: m.vec || { rx: 0, ry: 0, rz: 0, tx: 0, ty: 0, tz: 0 },
-      eigenvector: m.eigenvector || null,
-      stateOrder: m.stateOrder || null,
-    }));
+    return result.EIGEN.modes.map((m) => {
+      return {
+        name: m.name || 'Mode',
+        re: Number(m.re) || 0,
+        im: Number(m.im) || 0,
+        vec: m.vec || { rx: 0, ry: 0, rz: 0, tx: 0, ty: 0, tz: 0 },
+        eigenvector: m.eigenvector || null,
+        stateOrder: m.stateOrder || null,
+      };
+    });
   }
   return [];
 }
@@ -6907,6 +7812,183 @@ function drawPlotMessage(ctx, text, x, y, maxWidth, lineHeight = 17) {
   if (line) ctx.fillText(line, x, y + lineNo * lineHeight);
 }
 
+function nicePlotTicks(min, max, maxTicks = 5) {
+  const lo = Number(min);
+  const hi = Number(max);
+  if (!Number.isFinite(lo) || !Number.isFinite(hi) || hi <= lo) return [];
+  const target = Math.max(2, Number(maxTicks) || 5);
+  const rawStep = (hi - lo) / target;
+  const exp = Math.floor(Math.log10(Math.max(rawStep, 1e-12)));
+  const base = Math.pow(10, exp);
+  const step = ([1, 2, 5, 10].find((m) => rawStep <= m * base) || 10) * base;
+  const first = Math.ceil(lo / step) * step;
+  const ticks = [];
+  for (let value = first; value <= hi + step * 0.5; value += step) {
+    const rounded = Math.abs(value) < step * 1e-6 ? 0 : Number(value.toPrecision(12));
+    if (rounded >= lo - step * 1e-6 && rounded <= hi + step * 1e-6) ticks.push(rounded);
+    if (ticks.length > 24) break;
+  }
+  return ticks;
+}
+
+function eigenTickLabel(value) {
+  const v = Number(value);
+  if (!Number.isFinite(v)) return '';
+  const av = Math.abs(v);
+  if (av >= 10) return v.toFixed(0);
+  if (av >= 1) return v.toFixed(1);
+  if (av >= 0.1) return v.toFixed(2);
+  return v.toFixed(3);
+}
+
+function drawEigenGridTicksAndDamping(ctx, plot) {
+  const {
+    x0, y0, pw, ph, xFor, yFor, centerRe, centerIm, maxRe, maxIm,
+  } = plot;
+  const reMin = centerRe - maxRe;
+  const reMax = centerRe + maxRe;
+  const imMin = centerIm - maxIm;
+  const imMax = centerIm + maxIm;
+  const reTicks = nicePlotTicks(reMin, reMax, 5);
+  const imTicks = nicePlotTicks(imMin, imMax, 4);
+  ctx.save();
+  ctx.beginPath();
+  ctx.rect(x0, y0, pw, ph);
+  ctx.clip();
+  ctx.strokeStyle = 'rgba(148,163,184,0.11)';
+  ctx.lineWidth = 1;
+  reTicks.forEach((tick) => {
+    const x = xFor(tick);
+    ctx.beginPath();
+    ctx.moveTo(x, y0);
+    ctx.lineTo(x, y0 + ph);
+    ctx.stroke();
+  });
+  imTicks.forEach((tick) => {
+    const y = yFor(tick);
+    ctx.beginPath();
+    ctx.moveTo(x0, y);
+    ctx.lineTo(x0 + pw, y);
+    ctx.stroke();
+  });
+  const dampingRatio = 0.707;
+  const dampingSlope = Math.sqrt(Math.max(0, 1 - dampingRatio * dampingRatio)) / dampingRatio;
+  const dampingSegments = [];
+  [-1, 1].forEach((sign) => {
+    let tMin = Math.max(0, -reMax);
+    let tMax = Math.max(0, -reMin);
+    if (sign > 0) {
+      tMin = Math.max(tMin, imMin / dampingSlope);
+      tMax = Math.min(tMax, imMax / dampingSlope);
+    } else {
+      tMin = Math.max(tMin, -imMax / dampingSlope);
+      tMax = Math.min(tMax, -imMin / dampingSlope);
+    }
+    if (tMax <= tMin + 1e-12) return;
+    const a = { re: -tMin, im: sign * dampingSlope * tMin };
+    const b = { re: -tMax, im: sign * dampingSlope * tMax };
+    dampingSegments.push({ sign, a, b });
+    ctx.strokeStyle = 'rgba(148,163,184,0.55)';
+    ctx.setLineDash([5, 5]);
+    ctx.beginPath();
+    ctx.moveTo(xFor(a.re), yFor(a.im));
+    ctx.lineTo(xFor(b.re), yFor(b.im));
+    ctx.stroke();
+    ctx.setLineDash([]);
+  });
+  const labelSegment = dampingSegments.find((seg) => seg.sign > 0) || dampingSegments[0];
+  if (labelSegment) {
+    const tLabel = 0.62;
+    const re = labelSegment.a.re + (labelSegment.b.re - labelSegment.a.re) * tLabel;
+    const im = labelSegment.a.im + (labelSegment.b.im - labelSegment.a.im) * tLabel;
+    ctx.fillStyle = 'rgba(203,213,225,0.78)';
+    ctx.font = '10px Consolas, "Courier New", monospace';
+    ctx.fillText('ζ=0.707', xFor(re) + 6, yFor(im) - 6);
+  }
+  ctx.restore();
+
+  ctx.fillStyle = '#718096';
+  ctx.font = '10px Consolas, "Courier New", monospace';
+  reTicks.forEach((tick) => {
+    const x = xFor(tick);
+    if (x < x0 - 1 || x > x0 + pw + 1) return;
+    ctx.fillText(eigenTickLabel(tick), x - 12, y0 + ph + 16);
+  });
+  imTicks.forEach((tick) => {
+    const y = yFor(tick);
+    if (y < y0 - 1 || y > y0 + ph + 1) return;
+    ctx.fillText(eigenTickLabel(tick), 5, y + 3);
+  });
+  return {
+    reTicks,
+    imTicks,
+    dampingRatio,
+    dampingSegments: dampingSegments.length,
+    dampingLabel: 'ζ=0.707',
+  };
+}
+
+function eigenBoxZoomRect(vp = uiState.eigenViewport) {
+  if (!eigenPointerBox.active || !vp) return null;
+  const x1 = clampNumber(Number(eigenPointerBox.startX), vp.x0, vp.x0 + vp.pw);
+  const y1 = clampNumber(Number(eigenPointerBox.startY), vp.y0, vp.y0 + vp.ph);
+  let x2 = clampNumber(Number(eigenPointerBox.currentX), vp.x0, vp.x0 + vp.pw);
+  let y2 = clampNumber(Number(eigenPointerBox.currentY), vp.y0, vp.y0 + vp.ph);
+  const rawWidth = Math.abs(x2 - x1);
+  const rawHeight = Math.abs(y2 - y1);
+  const scaleLocked = Boolean(uiState.eigenScaleLocked);
+  const aspect = (Number(vp.pw) > 1e-9 && Number(vp.ph) > 1e-9) ? (Number(vp.pw) / Number(vp.ph)) : 1;
+  if (scaleLocked && rawWidth > 1e-9 && rawHeight > 1e-9 && Number.isFinite(aspect) && aspect > 1e-9) {
+    const sx = x2 >= x1 ? 1 : -1;
+    const sy = y2 >= y1 ? 1 : -1;
+    let width = rawWidth;
+    let height = rawHeight;
+    if ((width / height) > aspect) width = height * aspect;
+    else height = width / aspect;
+    x2 = x1 + sx * width;
+    y2 = y1 + sy * height;
+  }
+  const left = Math.min(x1, x2);
+  const right = Math.max(x1, x2);
+  const top = Math.min(y1, y2);
+  const bottom = Math.max(y1, y2);
+  return {
+    x1,
+    y1,
+    x2,
+    y2,
+    left,
+    right,
+    top,
+    bottom,
+    width: right - left,
+    height: bottom - top,
+    rawWidth,
+    rawHeight,
+    aspect,
+    scaleLocked,
+  };
+}
+
+function drawEigenBoxZoomOverlay(ctx) {
+  if (!eigenPointerBox.active || !uiState.eigenViewport) return;
+  const rect = eigenBoxZoomRect(uiState.eigenViewport);
+  if (!rect) return;
+  const left = rect.left;
+  const top = rect.top;
+  const boxW = rect.width;
+  const boxH = rect.height;
+  if (boxW < 2 || boxH < 2) return;
+  ctx.save();
+  ctx.fillStyle = 'rgba(125,211,252,0.10)';
+  ctx.strokeStyle = 'rgba(125,211,252,0.85)';
+  ctx.lineWidth = 1;
+  ctx.setLineDash([4, 3]);
+  ctx.fillRect(left, top, boxW, boxH);
+  ctx.strokeRect(left, top, boxW, boxH);
+  ctx.restore();
+}
+
 function drawEigenPlot() {
   const canvas = els.eigenPlot;
   if (!canvas?.getContext) return;
@@ -6927,7 +8009,7 @@ function drawEigenPlot() {
   ctx.fillStyle = getCssVarColor('--panel', '#0f1115');
   ctx.fillRect(0, 0, width, height);
 
-  const pad = { l: 44, r: 18, t: 20, b: 30 };
+  const pad = { l: 44, r: 72, t: 20, b: 30 };
   const x0 = pad.l;
   const y0 = pad.t;
   const pw = Math.max(1, width - pad.l - pad.r);
@@ -6937,6 +8019,7 @@ function drawEigenPlot() {
   if (!modes.length) {
     uiState.eigenPoints = [];
     uiState.eigenViewport = null;
+    uiState.eigenPlotRenderState = null;
     const message = uiState.eigenStatusMessage || 'No eigenmodes available yet. Run trim/EXEC first.';
     setEigenStatusMessage(message);
     if (!els.eigenStatus) {
@@ -6954,10 +8037,16 @@ function drawEigenPlot() {
     maxRe = Math.max(maxRe, Math.abs(Number(m.re) || 0));
     maxIm = Math.max(maxIm, Math.abs(Number(m.im) || 0));
   });
-  const zoom = Math.max(0.5, Math.min(8, Number(uiState.eigenZoom) || 1));
+  const zoom = Math.max(EIGEN_PLOT_MIN_ZOOM, Math.min(EIGEN_PLOT_MAX_ZOOM, Number(uiState.eigenZoom) || 1));
   uiState.eigenZoom = zoom;
   maxRe = Math.max(0.05, (maxRe * 1.2) / zoom);
   maxIm = Math.max(0.05, (maxIm * 1.2) / zoom);
+  if (uiState.eigenScaleLocked) {
+    const rePerPx = maxRe / Math.max(1, pw);
+    const imPerPx = maxIm / Math.max(1, ph);
+    if (rePerPx > imPerPx) maxIm = Math.max(maxIm, rePerPx * ph);
+    else maxRe = Math.max(maxRe, imPerPx * pw);
+  }
   const centerRe = Number.isFinite(uiState.eigenCenterRe) ? Number(uiState.eigenCenterRe) : 0;
   const centerIm = Number.isFinite(uiState.eigenCenterIm) ? Number(uiState.eigenCenterIm) : 0;
 
@@ -6965,9 +8054,18 @@ function drawEigenPlot() {
   const yFor = (im) => y0 + (1 - ((im - centerIm + maxIm) / (2 * maxIm))) * ph;
   const yMid = yFor(0);
   const xMid = xFor(0);
+  const reUnitsPerPixel = (2 * maxRe) / Math.max(1, pw);
+  const imUnitsPerPixel = (2 * maxIm) / Math.max(1, ph);
   uiState.eigenViewport = {
     xMid, yMid, maxRe, maxIm, zoom, centerRe, centerIm, x0, y0, pw, ph,
+    scaleLocked: Boolean(uiState.eigenScaleLocked),
+    reUnitsPerPixel,
+    imUnitsPerPixel,
   };
+
+  const gridState = drawEigenGridTicksAndDamping(ctx, {
+    x0, y0, pw, ph, xFor, yFor, centerRe, centerIm, maxRe, maxIm,
+  });
 
   ctx.strokeStyle = 'rgba(255,255,255,0.13)';
   ctx.lineWidth = 1;
@@ -6978,10 +8076,18 @@ function drawEigenPlot() {
   ctx.lineTo(xMid, y0 + ph);
   ctx.stroke();
 
+  const axisLabels = {
+    real: 'ℜ',
+    imag: 'ℑ',
+  };
+  const axisLabelPositions = {
+    real: { x: x0 + pw - 22, y: Math.max(y0 + 16, Math.min(y0 + ph - 6, yMid - 8)) },
+    imag: { x: Math.max(x0 + 6, Math.min(x0 + pw - 28, xMid + 8)), y: y0 + 16 },
+  };
   ctx.fillStyle = '#8ea2b8';
-  ctx.font = '11px Consolas, "Courier New", monospace';
-  ctx.fillText('Re', x0 + pw - 18, yMid - 6);
-  ctx.fillText('Im', xMid + 6, y0 + 12);
+  ctx.font = '16px Georgia, "Times New Roman", serif';
+  ctx.fillText(axisLabels.real, axisLabelPositions.real.x, axisLabelPositions.real.y);
+  ctx.fillText(axisLabels.imag, axisLabelPositions.imag.x, axisLabelPositions.imag.y);
 
   const runColor = activeRunCaseColor();
   const activeCaseIdx = activeRunCaseIndex();
@@ -6993,6 +8099,9 @@ function drawEigenPlot() {
     uiState.selectedEigenMode = -1;
     stopModeAnimation();
   }
+  const eigenSummary = summarizeDesignEigenModes(modes);
+  const classByIndex = new Map(eigenSummary.modes.map((mode) => [Number(mode.index), mode]));
+  const groupById = new Map((eigenSummary.groups || []).map((group) => [Number(group.id), group]));
   uiState.eigenPoints = [];
   modes.forEach((m, idx) => {
     const re = Number(m.re) || 0;
@@ -7027,7 +8136,15 @@ function drawEigenPlot() {
     ctx.arc(px, py, isSelected ? 5 : 4, 0, Math.PI * 2);
     ctx.fill();
     ctx.stroke();
-    if (Math.abs(im) > 1e-8) {
+    const modeClass = classByIndex.get(idx) || {
+      classKey: 'unknown',
+      classLabel: 'Unclassified',
+      labelVisible: false,
+      groupId: -1,
+    };
+    const group = groupById.get(Number(modeClass.groupId));
+    const hasExplicitConjugate = Boolean(group && Array.isArray(group.indices) && group.indices.length > 1);
+    if (Math.abs(im) > 1e-8 && !hasExplicitConjugate) {
       const py2 = yFor(-im);
       ctx.beginPath();
       ctx.arc(px, py2, isSelected ? 5 : 4, 0, Math.PI * 2);
@@ -7036,7 +8153,17 @@ function drawEigenPlot() {
     }
     ctx.fillStyle = modeSelectable ? '#c7d2fe' : '#6b7b95';
     ctx.font = '10px Consolas, "Courier New", monospace';
-    ctx.fillText(m.name, px + 8, py - 6);
+    const modeLabel = modeClass?.classKey && modeClass.classKey !== 'unknown'
+      ? modeClass.classLabel
+      : (m.name || `Mode ${idx + 1}`);
+    const shouldDrawLabel = Boolean(modeClass?.labelVisible || isSelected);
+    const labelOffsetY = im < 0 ? 14 : -6;
+    if (shouldDrawLabel) ctx.fillText(modeLabel, px + 8, py + labelOffsetY);
+    if (shouldDrawLabel && Math.abs(im) > 1e-8 && !hasExplicitConjugate) {
+      const py2 = yFor(-im);
+      const ghostOffsetY = (-im) < 0 ? 14 : -6;
+      ctx.fillText(modeLabel, px + 8, py2 + ghostOffsetY);
+    }
     if (isSelected) {
       const reTxt = (Number(m.re) || 0).toFixed(3);
       const imVal = Number(m.im) || 0;
@@ -7055,15 +8182,56 @@ function drawEigenPlot() {
       selectable: modeSelectable,
       runCaseIndex: modeRunCaseIdx,
       dimmed: !modeSelectable,
+      classKey: modeClass?.classKey || 'unknown',
+      classLabel: modeClass?.classLabel || 'Unclassified',
+      displayLabel: shouldDrawLabel ? modeLabel : '',
+      labelVisible: Boolean(modeClass?.labelVisible),
+      groupId: Number.isFinite(Number(modeClass?.groupId)) ? Number(modeClass.groupId) : -1,
+      representativeIndex: Number.isFinite(Number(modeClass?.representativeIndex)) ? Number(modeClass.representativeIndex) : idx,
     });
   });
+  drawEigenBoxZoomOverlay(ctx);
+  uiState.eigenPlotRenderState = {
+    ...gridState,
+    labels: uiState.eigenPoints.map((point) => ({
+      idx: point.idx,
+      classKey: point.classKey,
+      classLabel: point.classLabel,
+      displayLabel: point.displayLabel,
+      visible: Boolean(point.displayLabel),
+      groupId: point.groupId,
+    })),
+    axisLabels,
+    axisLabelPositions,
+    viewport: { ...uiState.eigenViewport },
+    scaleLocked: Boolean(uiState.eigenScaleLocked),
+    reUnitsPerPixel,
+    imUnitsPerPixel,
+    boxZoomActive: Boolean(eigenPointerBox.active),
+    boxZoomRect: eigenBoxZoomRect(uiState.eigenViewport),
+  };
 }
 
 function updateEigenButtons() {
   if (els.eigenPan) {
     els.eigenPan.classList.toggle('active', Boolean(uiState.eigenPanMode));
-    els.eigenPan.title = uiState.eigenPanMode ? 'Pan eigenmode plot on' : 'Pan eigenmode plot';
+    setViewerButtonTooltip(els.eigenPan, uiState.eigenPanMode ? 'Pan eigenmode plot on' : 'Pan eigenmode plot');
     els.eigenPan.setAttribute('aria-pressed', uiState.eigenPanMode ? 'true' : 'false');
+  }
+  if (els.eigenScaleLock) {
+    els.eigenScaleLock.classList.toggle('active', Boolean(uiState.eigenScaleLocked));
+    setViewerButtonTooltip(els.eigenScaleLock, uiState.eigenScaleLocked
+      ? 'Eigenmode axes locked to equal scale'
+      : 'Keep real and imaginary axes to the same scale');
+    els.eigenScaleLock.setAttribute('aria-pressed', uiState.eigenScaleLocked ? 'true' : 'false');
+  }
+  if (els.eigenDivergence) {
+    els.eigenDivergence.classList.toggle('active', Boolean(uiState.eigenShowDivergence));
+    setViewerButtonTooltip(
+      els.eigenDivergence,
+      uiState.eigenShowDivergence ? 'Unstable mode growth on' : 'Unstable mode growth off',
+    );
+    els.eigenDivergence.setAttribute('aria-pressed', uiState.eigenShowDivergence ? 'true' : 'false');
   }
 }
 
@@ -7075,8 +8243,8 @@ function resetEigenViewport() {
 }
 
 function zoomEigenByFactor(factor) {
-  const current = Math.max(0.5, Math.min(8, Number(uiState.eigenZoom) || 1));
-  const next = Math.max(0.5, Math.min(8, current * factor));
+  const current = Math.max(EIGEN_PLOT_MIN_ZOOM, Math.min(EIGEN_PLOT_MAX_ZOOM, Number(uiState.eigenZoom) || 1));
+  const next = Math.max(EIGEN_PLOT_MIN_ZOOM, Math.min(EIGEN_PLOT_MAX_ZOOM, current * factor));
   if (Math.abs(next - current) < 1e-4) return;
   const rect = els.eigenPlot?.getBoundingClientRect?.();
   const cx = rect ? (rect.left + (rect.width * 0.5)) : Number.NaN;
@@ -7094,6 +8262,44 @@ function setEigenPanMode(enabled) {
   drawEigenPlot();
 }
 
+function setEigenScaleLocked(enabled) {
+  uiState.eigenScaleLocked = Boolean(enabled);
+  updateEigenButtons();
+  drawEigenPlot();
+}
+
+function setEigenDivergenceMode(enabled) {
+  uiState.eigenShowDivergence = Boolean(enabled);
+  updateEigenButtons();
+  if (uiState.selectedEigenMode >= 0) startModeAnimation(uiState.selectedEigenMode);
+  else drawEigenPlot();
+}
+
+function eigenPlotRelativePoint(evt) {
+  const canvas = els.eigenPlot;
+  const rect = canvas?.getBoundingClientRect?.();
+  if (!rect) return null;
+  return {
+    x: (Number(evt?.clientX) || 0) - rect.left,
+    y: (Number(evt?.clientY) || 0) - rect.top,
+  };
+}
+
+function eigenPointInsidePlot(point, vp = uiState.eigenViewport) {
+  if (!point || !vp) return false;
+  return point.x >= vp.x0 && point.x <= vp.x0 + vp.pw && point.y >= vp.y0 && point.y <= vp.y0 + vp.ph;
+}
+
+function releaseEigenPointerCapture(pointerId) {
+  if (els.eigenPlot && typeof els.eigenPlot.releasePointerCapture === 'function' && pointerId != null) {
+    try {
+      els.eigenPlot.releasePointerCapture(pointerId);
+    } catch (_) {
+      // Ignore release errors for non-captured pointers.
+    }
+  }
+}
+
 function stopModeAnimation() {
   if (!modeAnimation) return;
   const basePos = modeAnimation.basePos?.clone?.();
@@ -7102,6 +8308,29 @@ function stopModeAnimation() {
   if (!aircraft) return;
   if (basePos) aircraft.position.copy(basePos);
   if (baseRot) aircraft.rotation.set(baseRot.x, baseRot.y, baseRot.z);
+}
+
+function eigenAnimationSigmaForMode(mode) {
+  const real = Number(mode?.re) || 0;
+  if (uiState.eigenShowDivergence) return real * EIGEN_MODE_ANIMATION_REAL_SCALE;
+  return -Math.max(0.01, Math.abs(real)) * EIGEN_MODE_ANIMATION_REAL_SCALE;
+}
+
+function eigenAnimationReferenceSpan() {
+  const bounds = aircraft ? computeBounds(aircraft) : null;
+  const ySpan = Number(bounds?.size?.y);
+  if (Number.isFinite(ySpan) && ySpan > 1e-6) return ySpan;
+  const maxDim = Number(bounds?.maxDim);
+  if (Number.isFinite(maxDim) && maxDim > 1e-6) return maxDim;
+  const designSpan = Number(readDesignAssistantSettings?.().span);
+  if (Number.isFinite(designSpan) && designSpan > 1e-6) return designSpan;
+  return 1;
+}
+
+function eigenAnimationPositionError(animation, scale) {
+  const v = animation?.vec || {};
+  const s = Number(scale) || 0;
+  return Math.hypot((Number(v.tx) || 0) * s, (Number(v.ty) || 0) * s, (Number(v.tz) || 0) * s);
 }
 
 function startModeAnimation(modeIndex) {
@@ -7114,7 +8343,7 @@ function startModeAnimation(modeIndex) {
     return;
   }
   const freq = Math.max(0.2, Math.abs(Number(mode.im) || 0));
-  const damp = Math.max(0.01, Math.abs(Number(mode.re) || 0));
+  const sigma = eigenAnimationSigmaForMode(mode);
   const raw = mode.vec || { rx: 0, ry: 0, rz: 0, tx: 0, ty: 0, tz: 0 };
   const rotMag = Math.max(Math.abs(raw.rx || 0), Math.abs(raw.ry || 0), Math.abs(raw.rz || 0), 1e-8);
   const posMag = Math.max(Math.abs(raw.tx || 0), Math.abs(raw.ty || 0), Math.abs(raw.tz || 0), 1e-8);
@@ -7126,19 +8355,37 @@ function startModeAnimation(modeIndex) {
     ty: (raw.ty || 0) * (0.25 / posMag),
     tz: (raw.tz || 0) * (0.25 / posMag),
   };
+  const showDivergence = Boolean(uiState.eigenShowDivergence);
+  const initialAmplitude = sigma > 0 && showDivergence
+    ? EIGEN_MODE_ANIMATION_DIVERGENCE_INITIAL_AMPLITUDE
+    : 1;
+  const referenceSpan = eigenAnimationReferenceSpan();
   modeAnimation = {
     started: performance.now(),
     basePos: aircraft.position.clone(),
     baseRot: aircraft.rotation.clone(),
     vec,
     w: 2 * Math.PI * freq,
-    sigma: damp * 0.25,
+    sigma,
+    rawReal: Number(mode.re) || 0,
+    showDivergence,
+    initialAmplitude,
+    amplitudeCap: sigma > 0 ? EIGEN_MODE_ANIMATION_DIVERGENCE_SAFETY_CAP : 1,
+    referenceSpan,
+    resetPositionError: Math.max(1e-6, referenceSpan * EIGEN_MODE_ANIMATION_DIVERGENCE_RESET_SPANS),
+    positionError: 0,
+    loopCount: 0,
+    elapsed: 0,
+    lastAmplitude: initialAmplitude,
+    lastRawAmplitude: 1,
   };
   drawEigenPlot();
 }
 
 function handleEigenCanvasClick(evt) {
   if (!els.eigenPlot) return;
+  if (performance.now() < eigenSuppressClickUntil) return;
+  if (Number(evt?.detail) > 1) return;
   if (uiState.eigenPanMode) return;
   const pts = (uiState.eigenPoints || []).filter((pt) => pt?.selectable !== false);
   if (!pts.length) return;
@@ -7162,18 +8409,45 @@ function handleEigenCanvasClick(evt) {
   startModeAnimation(best.idx);
 }
 
+function handleEigenCanvasDoubleClick(evt) {
+  if (!els.eigenPlot) return;
+  evt.preventDefault();
+  eigenSuppressClickUntil = performance.now() + 250;
+  eigenPointerBox.active = false;
+  eigenPointerPan.active = false;
+  resetEigenViewport();
+}
+
 function handleEigenPointerDown(evt) {
-  if (!els.eigenPlot || !uiState.eigenPanMode) return;
+  if (!els.eigenPlot) return;
   const vp = uiState.eigenViewport;
   if (!vp) return;
+  const point = eigenPlotRelativePoint(evt);
+  if (!eigenPointInsidePlot(point, vp)) return;
   evt.preventDefault();
-  eigenPointerPan = {
+  if (uiState.eigenPanMode) {
+    eigenPointerPan = {
+      active: true,
+      pointerId: evt.pointerId,
+      startX: Number(evt.clientX) || 0,
+      startY: Number(evt.clientY) || 0,
+      startCenterRe: Number.isFinite(uiState.eigenCenterRe) ? Number(uiState.eigenCenterRe) : 0,
+      startCenterIm: Number.isFinite(uiState.eigenCenterIm) ? Number(uiState.eigenCenterIm) : 0,
+    };
+    if (typeof els.eigenPlot.setPointerCapture === 'function' && evt.pointerId != null) {
+      els.eigenPlot.setPointerCapture(evt.pointerId);
+    }
+    drawEigenPlot();
+    return;
+  }
+  if (evt.button != null && evt.button !== 0) return;
+  eigenPointerBox = {
     active: true,
     pointerId: evt.pointerId,
-    startX: Number(evt.clientX) || 0,
-    startY: Number(evt.clientY) || 0,
-    startCenterRe: Number.isFinite(uiState.eigenCenterRe) ? Number(uiState.eigenCenterRe) : 0,
-    startCenterIm: Number.isFinite(uiState.eigenCenterIm) ? Number(uiState.eigenCenterIm) : 0,
+    startX: point.x,
+    startY: point.y,
+    currentX: point.x,
+    currentY: point.y,
   };
   if (typeof els.eigenPlot.setPointerCapture === 'function' && evt.pointerId != null) {
     els.eigenPlot.setPointerCapture(evt.pointerId);
@@ -7182,9 +8456,18 @@ function handleEigenPointerDown(evt) {
 }
 
 function handleEigenPointerMove(evt) {
-  if (!eigenPointerPan.active || !uiState.eigenPanMode) return;
   const vp = uiState.eigenViewport;
   if (!vp) return;
+  if (eigenPointerBox.active && !uiState.eigenPanMode) {
+    const point = eigenPlotRelativePoint(evt);
+    if (!point) return;
+    evt.preventDefault();
+    eigenPointerBox.currentX = clampNumber(point.x, vp.x0, vp.x0 + vp.pw);
+    eigenPointerBox.currentY = clampNumber(point.y, vp.y0, vp.y0 + vp.ph);
+    drawEigenPlot();
+    return;
+  }
+  if (!eigenPointerPan.active || !uiState.eigenPanMode) return;
   evt.preventDefault();
   const dx = (Number(evt.clientX) || 0) - eigenPointerPan.startX;
   const dy = (Number(evt.clientY) || 0) - eigenPointerPan.startY;
@@ -7196,35 +8479,62 @@ function handleEigenPointerMove(evt) {
 }
 
 function handleEigenPointerUp(evt) {
+  if (eigenPointerBox.active) {
+    if (evt?.pointerId != null && eigenPointerBox.pointerId != null && evt.pointerId !== eigenPointerBox.pointerId) return;
+    const vp = uiState.eigenViewport;
+    const point = eigenPlotRelativePoint(evt) || { x: eigenPointerBox.currentX, y: eigenPointerBox.currentY };
+    eigenPointerBox.currentX = vp ? clampNumber(point.x, vp.x0, vp.x0 + vp.pw) : point.x;
+    eigenPointerBox.currentY = vp ? clampNumber(point.y, vp.y0, vp.y0 + vp.ph) : point.y;
+    releaseEigenPointerCapture(evt?.pointerId);
+    const rect = eigenBoxZoomRect(vp);
+    const boxW = Number(rect?.width) || 0;
+    const boxH = Number(rect?.height) || 0;
+    const wasBoxZoom = vp && boxW >= EIGEN_PLOT_BOX_MIN_PX && boxH >= EIGEN_PLOT_BOX_MIN_PX;
+    eigenPointerBox.active = false;
+    eigenPointerBox.pointerId = null;
+    if (wasBoxZoom) {
+      const left = rect.left;
+      const right = rect.right;
+      const top = rect.top;
+      const bottom = rect.bottom;
+      const reForX = (x) => Number(vp.centerRe) - Number(vp.maxRe) + ((x - Number(vp.x0)) / Math.max(1, Number(vp.pw))) * 2 * Number(vp.maxRe);
+      const imForY = (y) => Number(vp.centerIm) + Number(vp.maxIm) - ((y - Number(vp.y0)) / Math.max(1, Number(vp.ph))) * 2 * Number(vp.maxIm);
+      const reA = reForX(left);
+      const reB = reForX(right);
+      const imA = imForY(bottom);
+      const imB = imForY(top);
+      const nextCenterRe = (reA + reB) * 0.5;
+      const nextCenterIm = (imA + imB) * 0.5;
+      const nextMaxRe = Math.max(1e-6, Math.abs(reB - reA) * 0.5);
+      const nextMaxIm = Math.max(1e-6, Math.abs(imB - imA) * 0.5);
+      const baseRe = Math.max(1e-6, Number(vp.maxRe) * Math.max(EIGEN_PLOT_MIN_ZOOM, Number(vp.zoom) || 1));
+      const baseIm = Math.max(1e-6, Number(vp.maxIm) * Math.max(EIGEN_PLOT_MIN_ZOOM, Number(vp.zoom) || 1));
+      uiState.eigenCenterRe = nextCenterRe;
+      uiState.eigenCenterIm = nextCenterIm;
+      uiState.eigenZoom = Math.max(EIGEN_PLOT_MIN_ZOOM, Math.min(EIGEN_PLOT_MAX_ZOOM, Math.min(baseRe / nextMaxRe, baseIm / nextMaxIm)));
+      eigenSuppressClickUntil = performance.now() + 250;
+    }
+    drawEigenPlot();
+    return;
+  }
   if (!eigenPointerPan.active) return;
   if (evt?.pointerId != null && eigenPointerPan.pointerId != null && evt.pointerId !== eigenPointerPan.pointerId) return;
-  if (els.eigenPlot && typeof els.eigenPlot.releasePointerCapture === 'function' && evt?.pointerId != null) {
-    try {
-      els.eigenPlot.releasePointerCapture(evt.pointerId);
-    } catch (_) {
-      // Ignore release errors for non-captured pointers.
-    }
-  }
+  releaseEigenPointerCapture(evt?.pointerId);
   eigenPointerPan.active = false;
   eigenPointerPan.pointerId = null;
   drawEigenPlot();
 }
 
 function handleEigenCanvasWheel(evt) {
-  if (!els.eigenPlot) return;
-  evt.preventDefault();
-  const current = Math.max(0.5, Math.min(8, Number(uiState.eigenZoom) || 1));
-  const factor = evt.deltaY < 0 ? 1.12 : (1 / 1.12);
-  const next = Math.max(0.5, Math.min(8, current * factor));
-  if (Math.abs(next - current) < 1e-4) return;
-  zoomEigenAtClient(next, evt.clientX, evt.clientY);
+  if (!els.eigenPlot || !evt) return;
+  // Wheel zoom is intentionally disabled so the page can scroll normally over the plot.
 }
 
 function zoomEigenAtClient(nextZoom, clientX, clientY) {
   const vp = uiState.eigenViewport;
   const canvas = els.eigenPlot;
   if (!vp || !canvas) {
-    uiState.eigenZoom = nextZoom;
+    uiState.eigenZoom = Math.max(EIGEN_PLOT_MIN_ZOOM, Math.min(EIGEN_PLOT_MAX_ZOOM, Number(nextZoom) || 1));
     drawEigenPlot();
     return;
   }
@@ -7235,7 +8545,7 @@ function zoomEigenAtClient(nextZoom, clientX, clientY) {
   const y = Math.max(vp.y0, Math.min(vp.y0 + vp.ph, relY));
   const nx = ((x - vp.x0) / Math.max(1, vp.pw)) * 2 - 1;
   const ny = (y - vp.y0) / Math.max(1, vp.ph);
-  const oldZoom = Math.max(0.5, Math.min(8, Number(vp.zoom) || Number(uiState.eigenZoom) || 1));
+  const oldZoom = Math.max(EIGEN_PLOT_MIN_ZOOM, Math.min(EIGEN_PLOT_MAX_ZOOM, Number(vp.zoom) || Number(uiState.eigenZoom) || 1));
   const oldMaxRe = Number(vp.maxRe) || 0.1;
   const oldMaxIm = Number(vp.maxIm) || 0.1;
   const centerRe = Number(vp.centerRe) || 0;
@@ -7248,7 +8558,7 @@ function zoomEigenAtClient(nextZoom, clientX, clientY) {
   const newMaxIm = Math.max(0.05, baseIm / nextZoom);
   uiState.eigenCenterRe = reAt - nx * newMaxRe;
   uiState.eigenCenterIm = imAt - (1 - 2 * ny) * newMaxIm;
-  uiState.eigenZoom = nextZoom;
+  uiState.eigenZoom = Math.max(EIGEN_PLOT_MIN_ZOOM, Math.min(EIGEN_PLOT_MAX_ZOOM, Number(nextZoom) || 1));
   drawEigenPlot();
 }
 
@@ -7276,8 +8586,8 @@ function handleEigenTouchMove(evt) {
   if (!Number.isFinite(dist) || dist <= 0 || !Number.isFinite(eigenTouchZoom.lastDist) || eigenTouchZoom.lastDist <= 0) return;
   const scale = dist / eigenTouchZoom.lastDist;
   if (!Number.isFinite(scale) || Math.abs(scale - 1) < 0.01) return;
-  const current = Math.max(0.5, Math.min(8, Number(uiState.eigenZoom) || 1));
-  const next = Math.max(0.5, Math.min(8, current * scale));
+  const current = Math.max(EIGEN_PLOT_MIN_ZOOM, Math.min(EIGEN_PLOT_MAX_ZOOM, Number(uiState.eigenZoom) || 1));
+  const next = Math.max(EIGEN_PLOT_MIN_ZOOM, Math.min(EIGEN_PLOT_MAX_ZOOM, current * scale));
   eigenTouchZoom.lastDist = dist;
   if (Math.abs(next - current) < 1e-4) return;
   const t0 = evt.touches[0];
@@ -7297,12 +8607,16 @@ function handleEigenTouchEnd(evt) {
 }
 
 function buildEigenmodeRows() {
-  const rows = [['run case', 'real eigenvalue', 'imag eigenvalue']];
+  const rows = [['run case', 'mode class', 'real eigenvalue', 'imag eigenvalue']];
   const modes = Array.isArray(uiState.eigenModes) ? uiState.eigenModes : [];
-  modes.forEach((mode) => {
+  const summary = summarizeDesignEigenModes(modes);
+  const classByIndex = new Map(summary.modes.map((mode) => [Number(mode.index), mode]));
+  modes.forEach((mode, index) => {
     const runCaseIdx = Number.isInteger(mode?.runCaseIndex) ? Number(mode.runCaseIndex) : -1;
+    const cls = classByIndex.get(index);
     rows.push([
       String(runCaseIdx >= 0 ? (runCaseIdx + 1) : runCaseIdx),
+      cls?.classLabel || 'Unclassified',
       fmt(Number(mode?.re) || 0, 6),
       fmt(Number(mode?.im) || 0, 6),
     ]);
@@ -7312,10 +8626,38 @@ function buildEigenmodeRows() {
 
 function updateModeAnimation() {
   if (!modeAnimation || !aircraft) return;
-  const t = (performance.now() - modeAnimation.started) / 1000;
-  const amp = Math.exp(-modeAnimation.sigma * t);
-  const osc = Math.sin(modeAnimation.w * t);
-  const s = amp * osc;
+  const now = performance.now();
+  let t = (now - modeAnimation.started) / 1000;
+  let rawAmp = Math.exp(modeAnimation.sigma * t);
+  let amp = modeAnimation.sigma > 0
+    ? Math.min(Number(modeAnimation.amplitudeCap) || EIGEN_MODE_ANIMATION_DIVERGENCE_SAFETY_CAP, (Number(modeAnimation.initialAmplitude) || EIGEN_MODE_ANIMATION_DIVERGENCE_INITIAL_AMPLITUDE) * rawAmp)
+    : rawAmp;
+  let osc = Math.sin(modeAnimation.w * t);
+  let s = amp * osc;
+  let positionError = eigenAnimationPositionError(modeAnimation, s);
+  const resetLimit = Number(modeAnimation.resetPositionError);
+  if (
+    modeAnimation.sigma > 0
+    && modeAnimation.showDivergence
+    && (
+      !Number.isFinite(rawAmp)
+      || !Number.isFinite(amp)
+      || (Number.isFinite(resetLimit) && resetLimit > 0 && positionError >= resetLimit)
+    )
+  ) {
+    modeAnimation.started = now;
+    modeAnimation.loopCount = Math.max(0, Math.floor(Number(modeAnimation.loopCount) || 0)) + 1;
+    t = 0;
+    rawAmp = 1;
+    amp = Number(modeAnimation.initialAmplitude) || EIGEN_MODE_ANIMATION_DIVERGENCE_INITIAL_AMPLITUDE;
+    osc = 0;
+    s = 0;
+    positionError = 0;
+  }
+  modeAnimation.elapsed = t;
+  modeAnimation.lastRawAmplitude = rawAmp;
+  modeAnimation.lastAmplitude = amp;
+  modeAnimation.positionError = positionError;
   const v = modeAnimation.vec;
   aircraft.position.set(
     modeAnimation.basePos.x + (v.tx || 0) * s,
@@ -7327,7 +8669,7 @@ function updateModeAnimation() {
     modeAnimation.baseRot.y + (v.ry || 0) * s,
     modeAnimation.baseRot.z + (v.rz || 0) * s,
   );
-  if (amp < 0.02) {
+  if (modeAnimation.sigma < 0 && amp < 0.02) {
     stopModeAnimation();
   }
 }
@@ -8130,16 +9472,24 @@ function queryPressureAtPoint(field, x, y, z) {
   return best;
 }
 
+function setViewerSkinMaterialColor(material, color, fillIntensity = VIEWER_SKIN_FILL_EMISSIVE_INTENSITY) {
+  if (!material || !color) return;
+  const col = color instanceof THREE.Color ? color : new THREE.Color(color);
+  if (material.color) material.color.copy(col);
+  if (material.emissive) {
+    material.emissive.copy(col);
+    material.emissiveIntensity = fillIntensity;
+  }
+  material.needsUpdate = true;
+}
+
 function updatePressureSurfaceColors() {
   if (!Array.isArray(surfaceSkinMeshes) || !surfaceSkinMeshes.length) return;
   const field = uiState.showPressure ? uiState.pressureField : null;
   surfaceSkinMeshes.forEach((mesh) => {
     const base = mesh.userData?.baseColor instanceof THREE.Color ? mesh.userData.baseColor : new THREE.Color(mesh.userData?.baseColor ?? 0x7dd3fc);
     const pressureBase = mesh.userData?.pressureBaseColor instanceof THREE.Color ? mesh.userData.pressureBaseColor : new THREE.Color(0xd8dce3);
-    if (mesh.material?.color) {
-      mesh.material.color.copy(field ? pressureBase : base);
-      mesh.material.needsUpdate = true;
-    }
+    setViewerSkinMaterialColor(mesh.material, field ? pressureBase : base);
   });
 
   if (!Array.isArray(surfacePressureMeshes) || !surfacePressureMeshes.length) return;
@@ -9239,6 +10589,57 @@ function rebuildAuxOverlays(bounds = null) {
   applyAuxOverlayVisibility();
 }
 
+function getOverlayReferenceSize(maxDim = null, fallback = 1) {
+  const explicit = Number(maxDim);
+  if (Number.isFinite(explicit) && explicit > 1e-9) return explicit;
+  const bref = Number(uiState.modelHeader?.bref ?? uiState.modelCache?.header?.bref);
+  if (Number.isFinite(bref) && Math.abs(bref) > 1e-9) return Math.abs(bref);
+  const cref = Number(uiState.modelHeader?.cref ?? uiState.modelCache?.header?.cref);
+  if (Number.isFinite(cref) && Math.abs(cref) > 1e-9) return Math.abs(cref) * 6;
+  const fb = Number(fallback);
+  return Number.isFinite(fb) && fb > 1e-9 ? fb : 1;
+}
+
+function applySurfaceLabelSpriteScale(sprite, maxDim = null) {
+  if (!sprite?.userData?.surfaceLabel) return;
+  const refSize = getOverlayReferenceSize(maxDim, sprite.userData.labelSurfaceScaleHint);
+  const image = sprite.material?.map?.image;
+  const canvasWidth = Number(image?.width ?? sprite.userData.labelCanvasWidthPx);
+  const canvasHeight = Number(image?.height ?? sprite.userData.labelCanvasHeightPx);
+  const aspect = Number.isFinite(canvasWidth) && Number.isFinite(canvasHeight) && canvasWidth > 0 && canvasHeight > 0
+    ? canvasWidth / canvasHeight
+    : 3;
+  let labelHeight = clampNumber(refSize * 0.045, 0.012, 0.18);
+  let labelWidth = labelHeight * aspect;
+  const maxLabelWidth = Math.max(labelHeight * 3, refSize * 0.6);
+  if (Number.isFinite(maxLabelWidth) && maxLabelWidth > 0 && labelWidth > maxLabelWidth) {
+    labelWidth = maxLabelWidth;
+    labelHeight = labelWidth / Math.max(1e-6, aspect);
+  }
+  const base = sprite.userData.labelBasePosition || {};
+  const x = Number(base.x);
+  const y = Number(base.y);
+  const z = Number(base.z);
+  const offset = clampNumber(refSize * 0.045, labelHeight * 1.25, 0.25);
+  if (Number.isFinite(x) && Number.isFinite(y) && Number.isFinite(z)) {
+    sprite.position.set(x, y, z + offset);
+  }
+  sprite.scale.set(labelWidth, labelHeight, 1);
+  sprite.userData.labelReferenceSize = refSize;
+  sprite.userData.labelWorldWidth = labelWidth;
+  sprite.userData.labelWorldHeight = labelHeight;
+  sprite.userData.labelWorldOffset = offset;
+}
+
+function applySurfaceLabelScales(target, maxDim = null) {
+  if (!target) return;
+  target.traverse((obj) => {
+    if (obj?.isSprite && obj?.userData?.surfaceLabel) {
+      applySurfaceLabelSpriteScale(obj, maxDim);
+    }
+  });
+}
+
 function buildSurfaceMesh(surface, color) {
   const group = new THREE.Group();
   group.userData.surfaceName = String(surface?.name || '');
@@ -9589,6 +10990,8 @@ function buildSurfaceMesh(surface, color) {
     const pressureBaseCol = new THREE.Color(0xd8dce3);
     const skinMat = new THREE.MeshStandardMaterial({
       color: baseCol,
+      emissive: baseCol.clone(),
+      emissiveIntensity: VIEWER_SKIN_FILL_EMISSIVE_INTENSITY,
       side: THREE.DoubleSide,
       metalness: 0.12,
       roughness: 0.5,
@@ -9609,6 +11012,8 @@ function buildSurfaceMesh(surface, color) {
     overlayGeom.setAttribute('alpha', new THREE.BufferAttribute(overlayAlpha, 1));
     const overlayMat = new THREE.MeshStandardMaterial({
       color: 0xffffff,
+      emissive: 0xffffff,
+      emissiveIntensity: VIEWER_PRESSURE_OVERLAY_FILL_EMISSIVE_INTENSITY,
       vertexColors: true,
       side: THREE.DoubleSide,
       metalness: 0.0,
@@ -9676,30 +11081,52 @@ function buildSurfaceMesh(surface, color) {
   const ty = Number(surface.translate?.[1] ?? 0);
   const tz = Number(surface.translate?.[2] ?? 0);
   const labelPos = [sx * cx + tx, sy * cy + ty, sz * cz + tz];
-  const xVals = surface.sections.map((s) => Number(s?.xle ?? 0));
-  const yVals = surface.sections.map((s) => Number(s?.yle ?? 0));
-  const zVals = surface.sections.map((s) => Number(s?.zle ?? 0));
+  const sectionExtentPoints = [];
+  surface.sections.forEach((section) => {
+    const xle = Number(section?.xle);
+    const yle = Number(section?.yle);
+    const zle = Number(section?.zle);
+    const chord = Number(section?.chord);
+    if (Number.isFinite(xle) && Number.isFinite(yle) && Number.isFinite(zle)) {
+      sectionExtentPoints.push([sx * xle + tx, sy * yle + ty, sz * zle + tz]);
+      if (Number.isFinite(chord) && chord > 0) {
+        sectionExtentPoints.push([sx * (xle + chord) + tx, sy * yle + ty, sz * zle + tz]);
+      }
+    }
+  });
+  if (typeof surface.yduplicate === 'number') {
+    const ydup = Number(surface.yduplicate);
+    if (Number.isFinite(ydup)) {
+      sectionExtentPoints.slice().forEach((p) => {
+        sectionExtentPoints.push([p[0], 2 * ydup - p[1], p[2]]);
+      });
+    }
+  }
+  const xVals = sectionExtentPoints.map((p) => Number(p?.[0] ?? 0));
+  const yVals = sectionExtentPoints.map((p) => Number(p?.[1] ?? 0));
+  const zVals = sectionExtentPoints.map((p) => Number(p?.[2] ?? 0));
   const chords = surface.sections.map((s) => Number(s?.chord ?? 0)).filter((v) => Number.isFinite(v) && v > 0);
   const xr = (xVals.length ? (Math.max(...xVals) - Math.min(...xVals)) : 0);
   const yr = (yVals.length ? (Math.max(...yVals) - Math.min(...yVals)) : 0);
   const zr = (zVals.length ? (Math.max(...zVals) - Math.min(...zVals)) : 0);
   const avgChord = chords.length ? (chords.reduce((a, b) => a + b, 0) / chords.length) : 0;
   const crefRaw = Number(uiState.modelHeader?.cref);
-  const chordWorld = Math.max(0.25, Number.isFinite(crefRaw) && crefRaw > 0 ? crefRaw : (avgChord * sx));
-  const sampleWidthPx = Math.max(1, Number(ctx?.measureText('XXXXXXXXXX').width) || 1);
-  const labelWidthPx = Math.max(sampleWidthPx, textWidthPx + (paddingXPx * 2));
-  const labelWidth = chordWorld * (labelWidthPx / sampleWidthPx);
-  sprite.position.set(labelPos[0], labelPos[1], labelPos[2] + 0.2);
-  sprite.scale.set(labelWidth, labelWidth * (labelCanvas.height / labelCanvas.width), 1);
+  const avgChordWorld = avgChord * Math.max(Math.abs(sx), 1e-6);
+  const chordWorld = Math.max(1e-6, Number.isFinite(crefRaw) && crefRaw > 0 ? crefRaw : avgChordWorld);
+  const surfaceScaleHint = Math.max(xr, yr, zr, avgChordWorld, chordWorld, 1e-6);
+  sprite.position.set(labelPos[0], labelPos[1], labelPos[2]);
   sprite.userData.surfaceLabel = true;
   sprite.userData.labelText = surfaceLabel;
-  sprite.userData.labelWidth = labelWidth;
   sprite.userData.chordWorld = chordWorld;
   sprite.userData.labelTextWidthPx = textWidthPx;
   sprite.userData.labelCanvasWidthPx = labelCanvas.width;
+  sprite.userData.labelCanvasHeightPx = labelCanvas.height;
   sprite.userData.labelPaddingXPx = paddingXPx;
   sprite.userData.labelFits = textWidthPx <= (labelCanvas.width - (paddingXPx * 2) + 0.5);
+  sprite.userData.labelBasePosition = { x: labelPos[0], y: labelPos[1], z: labelPos[2] };
+  sprite.userData.labelSurfaceScaleHint = surfaceScaleHint;
   sprite.userData.renderKind = 'wire';
+  applySurfaceLabelSpriteScale(sprite, surfaceScaleHint);
   group.add(sprite);
 
   return group;
@@ -10000,6 +11427,15 @@ let eigenPointerPan = {
   startCenterRe: 0,
   startCenterIm: 0,
 };
+let eigenPointerBox = {
+  active: false,
+  pointerId: null,
+  startX: 0,
+  startY: 0,
+  currentX: 0,
+  currentY: 0,
+};
+let eigenSuppressClickUntil = 0;
 let flowProjectTmp = null;
 let flowPointSpriteTexture = null;
 let massPointGroup = null;
@@ -10222,43 +11658,57 @@ function applyMassPointVisibility() {
   if (!showPoints) clearMassPointHover();
 }
 
+function setViewerButtonTooltip(button, text) {
+  if (!button) return;
+  const label = String(text || '').trim();
+  if (!label) return;
+  button.removeAttribute('title');
+  button.dataset.tooltip = label;
+  button.setAttribute('aria-label', label);
+}
+
 function updateViewerButtons() {
   if (!els.viewerPan || !els.viewerView || !els.viewerGrid) return;
   els.viewerPan.classList.toggle('active', viewerState.mode === 'pan');
   const viewLabel = viewerState.viewModes[viewerState.viewIndex] || 'top';
   const viewTitle = VIEW_MODE_LABELS[viewLabel] || viewLabel;
   const gridLabel = viewerState.gridModes[viewerState.gridIndex] || 'xy';
-  els.viewerView.title = `View: ${viewTitle}`;
-  els.viewerGrid.title = `Grid: ${gridLabel.toUpperCase()}`;
+  setViewerButtonTooltip(els.viewerHome, 'Fit to model');
+  setViewerButtonTooltip(els.viewerZoomIn, 'Zoom in');
+  setViewerButtonTooltip(els.viewerZoomOut, 'Zoom out');
+  setViewerButtonTooltip(els.viewerPan, viewerState.mode === 'pan' ? 'Pan mode on' : 'Pan mode');
+  setViewerButtonTooltip(els.viewerView, `View: ${viewTitle}`);
+  setViewerButtonTooltip(els.viewerGrid, `Grid: ${gridLabel.toUpperCase()}`);
   if (els.viewerLoad) {
     els.viewerLoad.classList.toggle('active', uiState.showLoading);
+    setViewerButtonTooltip(els.viewerLoad, uiState.showLoading ? 'Loading vectors on' : 'Loading vectors off');
   }
   if (els.viewerText) {
     els.viewerText.classList.toggle('active', uiState.showSurfaceText);
-    els.viewerText.title = uiState.showSurfaceText ? 'Surface labels on' : 'Surface labels off';
+    setViewerButtonTooltip(els.viewerText, uiState.showSurfaceText ? 'Surface labels on' : 'Surface labels off');
   }
   if (els.viewerMassPoints) {
     els.viewerMassPoints.classList.toggle('active', uiState.showMassPoints);
-    els.viewerMassPoints.title = uiState.showMassPoints ? 'Mass points on' : 'Mass points off';
+    setViewerButtonTooltip(els.viewerMassPoints, uiState.showMassPoints ? 'Mass points on' : 'Mass points off');
   }
   if (els.viewerSurface) {
     const mode = uiState.surfaceRenderMode;
     els.viewerSurface.classList.toggle('active', mode !== 'wireframe');
-    if (mode === 'wireframe') els.viewerSurface.title = 'Render: wireframe only';
-    else if (mode === 'both') els.viewerSurface.title = 'Render: surface + wireframe';
-    else els.viewerSurface.title = 'Render: surface only';
+    if (mode === 'wireframe') setViewerButtonTooltip(els.viewerSurface, 'Render: wireframe only');
+    else if (mode === 'both') setViewerButtonTooltip(els.viewerSurface, 'Render: surface + wireframe');
+    else setViewerButtonTooltip(els.viewerSurface, 'Render: surface only');
   }
   if (els.viewerPressure) {
     els.viewerPressure.classList.toggle('active', uiState.showPressure);
-    els.viewerPressure.title = uiState.showPressure ? 'Pressure shading on' : 'Pressure shading off';
+    setViewerButtonTooltip(els.viewerPressure, uiState.showPressure ? 'Pressure shading on' : 'Pressure shading off');
   }
   if (els.viewerPanelSpacing) {
     els.viewerPanelSpacing.classList.toggle('active', uiState.showPanelSpacing);
-    els.viewerPanelSpacing.title = uiState.showPanelSpacing ? 'Panel spacing on' : 'Panel spacing off';
+    setViewerButtonTooltip(els.viewerPanelSpacing, uiState.showPanelSpacing ? 'Panel spacing on' : 'Panel spacing off');
   }
   if (els.viewerVortices) {
     els.viewerVortices.classList.toggle('active', uiState.showVortices);
-    els.viewerVortices.title = uiState.showVortices ? 'Bound + leg vortices on' : 'Bound + leg vortices off';
+    setViewerButtonTooltip(els.viewerVortices, uiState.showVortices ? 'Bound + leg vortices on' : 'Bound + leg vortices off');
   }
   if (els.viewerFlow) {
     els.viewerFlow.classList.toggle('active', uiState.showFlowField);
@@ -10266,9 +11716,10 @@ function updateViewerButtons() {
     const modeLabel = mode === 'induced'
       ? 'induced only'
       : (mode === 'induced+rotation' ? 'induced + body-rotation' : 'full flow');
-    els.viewerFlow.title = uiState.showFlowField
-      ? `Flow: ${modeLabel} (tap to cycle)`
-      : `Flow off (next: ${modeLabel})`;
+    setViewerButtonTooltip(
+      els.viewerFlow,
+      uiState.showFlowField ? `Flow: ${modeLabel} (tap to cycle)` : `Flow off (next: ${modeLabel})`,
+    );
   }
 }
 
@@ -10662,11 +12113,13 @@ function buildExecState(model) {
   const hasCdcl = Array.isArray(model?.surfaces)
     && model.surfaces.some((surf) => Array.isArray(surf?.sections)
       && surf.sections.some((sec) => Array.isArray(sec?.cdcl) && sec.cdcl.length >= 6 && Number(sec.cdcl[3]) !== 0));
+  const activeMassProps = uiState.massProps || {};
   const unitlMassFile = Number(uiState.massFileProps?.lunitScale);
-  const unitlMass = Number(uiState.massProps?.lunitScale);
+  const unitlMass = Number(activeMassProps?.lunitScale);
   const unitlUse = (Number.isFinite(unitlMassFile) && unitlMassFile > 0)
     ? unitlMassFile
     : ((Number.isFinite(unitlMass) && unitlMass > 0) ? unitlMass : 1.0);
+  const hasActivePrincipalInertias = ['ixx', 'iyy', 'izz'].every((key) => Number(activeMassProps?.[key]) > 0);
   const IVALFA = 1;
   const IVBETA = 2;
   const IVROTX = 3;
@@ -10824,7 +12277,7 @@ function buildExecState(model) {
     LBFORCE: false,
     LTRFORCE: false,
     LNFLD_WV: false,
-    LMASS: Boolean(uiState.massPropsFilename),
+    LMASS: Boolean(uiState.massPropsFilename || hasActivePrincipalInertias),
     LFLOAD: new Uint8Array(NSURF + 1),
 
     ALFA: 0.0,
@@ -11084,31 +12537,32 @@ function buildExecState(model) {
   state.PARVAL[idx2(IPRHO, IR, IPTOT)] = Math.fround(Number(els.rho.value));
   state.PARVAL[idx2(IPGEE, IR, IPTOT)] = Math.fround(Number(els.gee.value));
   {
-    const massVal = Number(uiState.massProps?.mass ?? els.mass?.value ?? 0);
+    const massVal = Number(activeMassProps?.mass ?? els.mass?.value ?? 0);
     const massUse = massVal > 0 ? massVal : 1.0;
     state.PARVAL[idx2(IPMASS, IR, IPTOT)] = Math.fround(massUse);
   }
   state.PARVAL[idx2(IPCL, IR, IPTOT)] = Math.fround(Number(els.cl?.value || 0));
   state.PARVAL[idx2(IPPHI, IR, IPTOT)] = Math.fround(Number(els.bank?.value || 0));
-  const xcgInput = Number(els.xcg?.value);
-  const ycgInput = Number(els.ycg?.value);
-  const zcgInput = Number(els.zcg?.value);
+  const useCgInputs = !false;
+  const xcgInput = useCgInputs ? Number(els.xcg?.value) : Number.NaN;
+  const ycgInput = useCgInputs ? Number(els.ycg?.value) : Number.NaN;
+  const zcgInput = useCgInputs ? Number(els.zcg?.value) : Number.NaN;
   state.PARVAL[idx2(IPXCG, IR, IPTOT)] = Math.fround(Number.isFinite(xcgInput)
     ? xcgInput
-    : (Number.isFinite(uiState.massProps?.xcg) ? uiState.massProps.xcg : (Number.isFinite(model.header.xref) ? model.header.xref : 0.0)));
+    : (Number.isFinite(activeMassProps?.xcg) ? activeMassProps.xcg : (Number.isFinite(model.header.xref) ? model.header.xref : 0.0)));
   state.PARVAL[idx2(IPYCG, IR, IPTOT)] = Math.fround(Number.isFinite(ycgInput)
     ? ycgInput
-    : (Number.isFinite(uiState.massProps?.ycg) ? uiState.massProps.ycg : (Number.isFinite(model.header.yref) ? model.header.yref : 0.0)));
+    : (Number.isFinite(activeMassProps?.ycg) ? activeMassProps.ycg : (Number.isFinite(model.header.yref) ? model.header.yref : 0.0)));
   state.PARVAL[idx2(IPZCG, IR, IPTOT)] = Math.fround(Number.isFinite(zcgInput)
     ? zcgInput
-    : (Number.isFinite(uiState.massProps?.zcg) ? uiState.massProps.zcg : (Number.isFinite(model.header.zref) ? model.header.zref : 0.0)));
-  state.PARVAL[idx2(IPIXX, IR, IPTOT)] = Math.fround(Number.isFinite(uiState.massProps?.ixx) ? uiState.massProps.ixx : 0.0);
-  state.PARVAL[idx2(IPIYY, IR, IPTOT)] = Math.fround(Number.isFinite(uiState.massProps?.iyy) ? uiState.massProps.iyy : 0.0);
-  state.PARVAL[idx2(IPIZZ, IR, IPTOT)] = Math.fround(Number.isFinite(uiState.massProps?.izz) ? uiState.massProps.izz : 0.0);
+    : (Number.isFinite(activeMassProps?.zcg) ? activeMassProps.zcg : (Number.isFinite(model.header.zref) ? model.header.zref : 0.0)));
+  state.PARVAL[idx2(IPIXX, IR, IPTOT)] = Math.fround(Number.isFinite(activeMassProps?.ixx) ? activeMassProps.ixx : 0.0);
+  state.PARVAL[idx2(IPIYY, IR, IPTOT)] = Math.fround(Number.isFinite(activeMassProps?.iyy) ? activeMassProps.iyy : 0.0);
+  state.PARVAL[idx2(IPIZZ, IR, IPTOT)] = Math.fround(Number.isFinite(activeMassProps?.izz) ? activeMassProps.izz : 0.0);
   // AVL stores products of inertia with opposite sign internally.
-  state.PARVAL[idx2(IPIXY, IR, IPTOT)] = Math.fround(Number.isFinite(uiState.massProps?.ixy) ? -uiState.massProps.ixy : 0.0);
-  state.PARVAL[idx2(IPIZX, IR, IPTOT)] = Math.fround(Number.isFinite(uiState.massProps?.ixz) ? -uiState.massProps.ixz : 0.0);
-  state.PARVAL[idx2(IPIYZ, IR, IPTOT)] = Math.fround(Number.isFinite(uiState.massProps?.iyz) ? -uiState.massProps.iyz : 0.0);
+  state.PARVAL[idx2(IPIXY, IR, IPTOT)] = Math.fround(Number.isFinite(activeMassProps?.ixy) ? -activeMassProps.ixy : 0.0);
+  state.PARVAL[idx2(IPIZX, IR, IPTOT)] = Math.fround(Number.isFinite(activeMassProps?.ixz) ? -activeMassProps.ixz : 0.0);
+  state.PARVAL[idx2(IPIYZ, IR, IPTOT)] = Math.fround(Number.isFinite(activeMassProps?.iyz) ? -activeMassProps.iyz : 0.0);
   {
     const cd0 = Number(runInputs?.cd0);
     state.PARVAL[idx2(IPCD0, IR, IPTOT)] = Math.fround(Number.isFinite(cd0) ? cd0 : 0.0);

--- a/js/dist/styles.css
+++ b/js/dist/styles.css
@@ -894,6 +894,53 @@ textarea.code {
   color: #22d3ee;
 }
 
+.viewer-overlay .viewer-btn[data-tooltip]::after,
+.viewer-overlay-bottom .viewer-btn[data-tooltip]::after,
+.eigen-overlay .viewer-btn[data-tooltip]::after {
+  position: absolute;
+  z-index: 40;
+  width: max-content;
+  max-width: 220px;
+  padding: 5px 7px;
+  border: 1px solid rgba(125, 211, 252, 0.38);
+  border-radius: 6px;
+  background: rgba(2, 6, 23, 0.96);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+  color: #e5f4ff;
+  content: attr(data-tooltip);
+  font: 600 11px/1.2 Consolas, "Courier New", monospace;
+  letter-spacing: 0;
+  opacity: 0;
+  pointer-events: none;
+  text-transform: none;
+  transition: none;
+  visibility: hidden;
+  white-space: normal;
+}
+
+.viewer-overlay .viewer-btn[data-tooltip]::after,
+.eigen-overlay .viewer-btn[data-tooltip]::after {
+  top: 50%;
+  right: calc(100% + 8px);
+  transform: translateY(-50%);
+}
+
+.viewer-overlay-bottom .viewer-btn[data-tooltip]::after {
+  left: 0;
+  bottom: calc(100% + 8px);
+  transform: none;
+}
+
+.viewer-overlay .viewer-btn[data-tooltip]:hover::after,
+.viewer-overlay .viewer-btn[data-tooltip]:focus-visible::after,
+.viewer-overlay-bottom .viewer-btn[data-tooltip]:hover::after,
+.viewer-overlay-bottom .viewer-btn[data-tooltip]:focus-visible::after,
+.eigen-overlay .viewer-btn[data-tooltip]:hover::after,
+.eigen-overlay .viewer-btn[data-tooltip]:focus-visible::after {
+  opacity: 1;
+  visibility: visible;
+}
+
 .plot {
   width: 100%;
   height: clamp(200px, 30vh, 320px);
@@ -996,10 +1043,10 @@ textarea.code {
   right: 6px;
   background: transparent;
   border-radius: 8px;
-  padding: 4px 6px;
+  padding: 5px 7px;
   display: grid;
-  gap: 0;
-  font: 16px Consolas, "Courier New", monospace;
+  gap: 2px;
+  font: 20px Consolas, "Courier New", monospace;
   color: #9aa8b7;
 }
 
@@ -1098,10 +1145,10 @@ textarea.code {
 .trefftz-legend-item {
   display: flex;
   align-items: center;
-  gap: 4px;
-  margin: -0.5em 0 0 0;
+  gap: 6px;
+  margin: -0.35em 0 0 0;
   padding: 0;
-  line-height: 1;
+  line-height: 1.05;
 }
 
 .trefftz-legend-item:first-child {
@@ -1109,9 +1156,9 @@ textarea.code {
 }
 
 .trefftz-legend-item .swatch.line {
-  width: 14px;
-  height: 10px;
-  stroke-width: 1.2;
+  width: 18px;
+  height: 12px;
+  stroke-width: 1.6;
   fill: none;
   flex: 0 0 auto;
 }

--- a/js/playwright/eigenmode_panel.spec.js
+++ b/js/playwright/eigenmode_panel.spec.js
@@ -70,17 +70,89 @@ test('eigenmode panel sits between trefftz and AVL editor, and canvas click sele
     await expect(page.locator('#eigenZoomIn')).toHaveCount(1);
     await expect(page.locator('#eigenZoomOut')).toHaveCount(1);
     await expect(page.locator('#eigenPan')).toHaveCount(1);
+    await expect(page.locator('#eigenScaleLock')).toHaveCount(1);
+    await expect(page.locator('#eigenDivergence')).toHaveCount(1);
     await expect(page.locator('#eigenDownload')).toHaveCount(1);
+    const eigenButtonIds = ['eigenHome', 'eigenZoomIn', 'eigenZoomOut', 'eigenPan', 'eigenScaleLock', 'eigenDownload'];
+    const eigenTooltipState = await page.evaluate((ids) => ids.map((id) => {
+      const node = document.getElementById(id);
+      return {
+        id,
+        title: node?.getAttribute('title') || '',
+        ariaLabel: node?.getAttribute('aria-label') || '',
+        tooltip: node?.getAttribute('data-tooltip') || '',
+      };
+    }), eigenButtonIds);
+    expect(eigenTooltipState.every((item) => item.title.length === 0)).toBeTruthy();
+    expect(eigenTooltipState.every((item) => item.ariaLabel.length > 0)).toBeTruthy();
+    expect(eigenTooltipState.every((item) => item.tooltip === item.ariaLabel)).toBeTruthy();
+    await page.hover('#eigenHome');
+    const eigenInstantTooltip = await page.evaluate(() => {
+      const node = document.getElementById('eigenHome');
+      const style = window.getComputedStyle(node, '::after');
+      return {
+        content: style.content,
+        opacity: style.opacity,
+        transitionDelay: style.transitionDelay,
+        transitionDuration: style.transitionDuration,
+        visibility: style.visibility,
+      };
+    });
+    expect(eigenInstantTooltip.content).toContain('Reset eigenmode view');
+    expect(eigenInstantTooltip.opacity).toBe('1');
+    expect(eigenInstantTooltip.visibility).toBe('visible');
+    expect(eigenInstantTooltip.transitionDelay).toBe('0s');
+    expect(eigenInstantTooltip.transitionDuration).toBe('0s');
 
     await page.waitForFunction(() => typeof window.__trefftzTestHook !== 'undefined');
+    await page.waitForFunction(() => Boolean(window.__trefftzTestHook.getLastExecResult?.()), null, { timeout: 15000 }).catch(() => {});
     const points = await page.evaluate(() => {
+      const stateOrder = ['u', 'w', 'q', 'theta', 'v', 'p', 'r', 'phi', 'x', 'y', 'z', 'psi'];
+      const eigenvector = (components) => ({
+        re: stateOrder.map((key) => Number(components[key]) || 0),
+        im: stateOrder.map(() => 0),
+      });
       window.__trefftzTestHook.setRunCasesForTest([
         { name: 'Case Alpha', color: '#ff5500' },
         { name: 'Case Beta', color: '#00aa88' },
       ], 0);
       window.__trefftzTestHook.setEigenModes([
-        { name: 'Test A', re: -0.2, im: 0.12, runCaseIndex: 0, vec: { rx: 0.05, ry: 0, rz: 0, tx: 0, ty: 0, tz: 0 } },
-        { name: 'Test B', re: -0.05, im: 0.02, runCaseIndex: 1, vec: { rx: 0, ry: 0.05, rz: 0, tx: 0.1, ty: 0, tz: 0 } },
+        {
+          name: 'Test A',
+          re: -0.2,
+          im: 0.12,
+          runCaseIndex: 0,
+          stateOrder,
+          eigenvector: eigenvector({ q: 1, theta: 0.8, w: 0.5 }),
+          vec: { rx: 0, ry: 0.05, rz: 0, tx: 0, ty: 0, tz: 0 },
+        },
+        {
+          name: 'Test A conjugate',
+          re: -0.2,
+          im: -0.12,
+          runCaseIndex: 0,
+          stateOrder,
+          eigenvector: eigenvector({ q: 1, theta: 0.8, w: 0.5 }),
+          vec: { rx: 0, ry: 0.05, rz: 0, tx: 0, ty: 0, tz: 0 },
+        },
+        {
+          name: 'Pitch-like extra root',
+          re: -0.11,
+          im: 0.04,
+          runCaseIndex: 0,
+          stateOrder,
+          eigenvector: eigenvector({ q: 1, theta: 0.75, w: 0.5 }),
+          vec: { rx: 0, ry: 0.04, rz: 0, tx: 0, ty: 0, tz: 0 },
+        },
+        {
+          name: 'Test B',
+          re: -0.05,
+          im: 0.02,
+          runCaseIndex: 1,
+          stateOrder,
+          eigenvector: eigenvector({ v: 1, r: 0.8, psi: 0.6 }),
+          vec: { rx: 0, ry: 0, rz: 0.05, tx: 0, ty: 0.1, tz: 0 },
+        },
       ]);
       return window.__trefftzTestHook.getEigenPoints();
     });
@@ -88,6 +160,77 @@ test('eigenmode panel sits between trefftz and AVL editor, and canvas click sele
     expect(points.length).toBeGreaterThan(0);
     const activeCaseColor = await page.locator('#runCaseList .run-case-item').first().locator('.run-case-color').inputValue();
     expect(points[0].color).toBe(activeCaseColor.toLowerCase());
+    expect(points[0].classLabel).toBe('Short period');
+    const renderState = await page.evaluate(() => window.__trefftzTestHook.getEigenPlotRenderState());
+    expect(renderState.labels.map((label) => label.classLabel)).toContain('Short period');
+    expect(renderState.labels.map((label) => label.classLabel)).toContain('Dutch roll');
+    expect(renderState.labels.filter((label) => label.classLabel === 'Short period' && label.visible)).toHaveLength(2);
+    expect(renderState.labels.map((label) => label.classLabel)).toContain('Unclassified');
+    expect(renderState.axisLabels).toEqual({ real: 'ℜ', imag: 'ℑ' });
+    const axisLayout = await page.evaluate(() => {
+      const state = window.__trefftzTestHook.getEigenPlotRenderState();
+      const canvas = document.querySelector('#eigenPlot');
+      return {
+        canvasWidth: canvas?.clientWidth || 0,
+        plotRight: (state?.viewport?.x0 || 0) + (state?.viewport?.pw || 0),
+        realLabelX: state?.axisLabelPositions?.real?.x || 0,
+      };
+    });
+    expect(axisLayout.plotRight).toBeLessThan(axisLayout.canvasWidth - 45);
+    expect(axisLayout.realLabelX).toBeLessThan(axisLayout.canvasWidth - 60);
+    expect(renderState.reTicks.length).toBeGreaterThan(2);
+    expect(renderState.imTicks.length).toBeGreaterThan(2);
+    expect(renderState.dampingLabel).toBe('ζ=0.707');
+    expect(renderState.dampingSegments).toBeGreaterThan(0);
+    await expect(page.locator('#eigenScaleLock')).toHaveAttribute('aria-pressed', 'false');
+    await page.click('#eigenScaleLock');
+    await expect(page.locator('#eigenScaleLock')).toHaveAttribute('aria-pressed', 'true');
+    await expect(page.locator('#eigenScaleLock')).not.toHaveAttribute('title', /.+/);
+    await expect(page.locator('#eigenScaleLock')).toHaveAttribute('data-tooltip', 'Eigenmode axes locked to equal scale');
+    await page.waitForFunction(() => window.__trefftzTestHook.getEigenViewport()?.scaleLocked);
+    const lockedViewport = await page.evaluate(() => window.__trefftzTestHook.getEigenViewport());
+    expect(Math.abs(lockedViewport.reUnitsPerPixel - lockedViewport.imUnitsPerPixel)).toBeLessThan(1e-9);
+    await page.click('#eigenZoomIn');
+    await page.waitForFunction((z) => window.__trefftzTestHook.getEigenViewport()?.zoom > z, lockedViewport.zoom);
+    const lockedZoomViewport = await page.evaluate(() => window.__trefftzTestHook.getEigenViewport());
+    expect(Math.abs(lockedZoomViewport.reUnitsPerPixel - lockedZoomViewport.imUnitsPerPixel)).toBeLessThan(1e-9);
+    const scaleLockedDrag = await page.evaluate(() => {
+      const canvas = document.querySelector('#eigenPlot');
+      const rect = canvas?.getBoundingClientRect();
+      const vp = window.__trefftzTestHook.getEigenViewport();
+      return {
+        startX: rect.left + vp.x0 + vp.pw * 0.20,
+        startY: rect.top + vp.y0 + vp.ph * 0.25,
+        endX: rect.left + vp.x0 + vp.pw * 0.65,
+        endY: rect.top + vp.y0 + vp.ph * 0.35,
+      };
+    });
+    await page.mouse.move(scaleLockedDrag.startX, scaleLockedDrag.startY);
+    await page.mouse.down();
+    await page.mouse.move(scaleLockedDrag.endX, scaleLockedDrag.endY, { steps: 8 });
+    await page.waitForFunction(() => window.__trefftzTestHook.getEigenPlotRenderState()?.boxZoomActive);
+    const lockedBoxPreview = await page.evaluate(() => {
+      const state = window.__trefftzTestHook.getEigenPlotRenderState();
+      const rect = state.boxZoomRect;
+      return {
+        scaleLocked: Boolean(rect?.scaleLocked),
+        width: Number(rect?.width),
+        height: Number(rect?.height),
+        rawAspect: Number(rect?.rawWidth) / Number(rect?.rawHeight),
+        previewAspect: Number(rect?.width) / Number(rect?.height),
+        targetAspect: Number(state?.viewport?.pw) / Number(state?.viewport?.ph),
+      };
+    });
+    expect(lockedBoxPreview.scaleLocked).toBe(true);
+    expect(lockedBoxPreview.width).toBeGreaterThan(8);
+    expect(lockedBoxPreview.height).toBeGreaterThan(8);
+    expect(Math.abs(lockedBoxPreview.rawAspect - lockedBoxPreview.targetAspect)).toBeGreaterThan(0.5);
+    expect(Math.abs(lockedBoxPreview.previewAspect - lockedBoxPreview.targetAspect)).toBeLessThan(1e-6);
+    await page.mouse.up();
+    await page.waitForFunction(() => !window.__trefftzTestHook.getEigenPlotRenderState()?.boxZoomActive);
+    await page.click('#eigenScaleLock');
+    await expect(page.locator('#eigenScaleLock')).toHaveAttribute('aria-pressed', 'false');
+    await page.click('#eigenHome');
     const viewportBeforeZoomIn = await page.evaluate(() => window.__trefftzTestHook.getEigenViewport());
     expect(viewportBeforeZoomIn).toBeTruthy();
 
@@ -99,10 +242,12 @@ test('eigenmode panel sits between trefftz and AVL editor, and canvas click sele
 
     await page.click('#eigenZoomOut');
     await page.waitForFunction((z) => window.__trefftzTestHook.getEigenViewport()?.zoom < z, viewportAfterZoomIn.zoom);
-    const viewportAfterWheelZoomOut = await page.evaluate(() => window.__trefftzTestHook.getEigenViewport());
+    const viewportAfterZoomOut = await page.evaluate(() => window.__trefftzTestHook.getEigenViewport());
 
     await page.click('#eigenPan');
     await expect.poll(async () => page.evaluate(() => window.__trefftzTestHook.getEigenPanMode())).toBe(true);
+    await expect(page.locator('#eigenPan')).not.toHaveAttribute('title', /.+/);
+    await expect(page.locator('#eigenPan')).toHaveAttribute('data-tooltip', 'Pan eigenmode plot on');
     const viewportBeforePan = await page.evaluate(() => window.__trefftzTestHook.getEigenViewport());
     const canvasBox = await page.locator('#eigenPlot').boundingBox();
     expect(canvasBox).toBeTruthy();
@@ -125,6 +270,34 @@ test('eigenmode panel sits between trefftz and AVL editor, and canvas click sele
     await page.click('#eigenPan');
     await expect.poll(async () => page.evaluate(() => window.__trefftzTestHook.getEigenPanMode())).toBe(false);
 
+    await page.evaluate(() => {
+      const canvas = document.querySelector('#eigenPlot');
+      if (!canvas) return;
+      canvas.dispatchEvent(new WheelEvent('wheel', { bubbles: true, cancelable: true, deltaY: -360 }));
+    });
+    await page.waitForTimeout(80);
+    const viewportAfterWheel = await page.evaluate(() => window.__trefftzTestHook.getEigenViewport());
+    expect(viewportAfterWheel.zoom).toBeCloseTo(viewportAfterZoomOut.zoom, 6);
+    expect(viewportAfterWheel.maxRe).toBeCloseTo(viewportAfterZoomOut.maxRe, 6);
+
+    const viewportBeforeBox = await page.evaluate(() => window.__trefftzTestHook.getEigenViewport());
+    const boxCanvas = await page.locator('#eigenPlot').boundingBox();
+    expect(boxCanvas).toBeTruthy();
+    await page.mouse.move(boxCanvas.x + (boxCanvas.width * 0.30), boxCanvas.y + (boxCanvas.height * 0.30));
+    await page.mouse.down();
+    await page.mouse.move(boxCanvas.x + (boxCanvas.width * 0.58), boxCanvas.y + (boxCanvas.height * 0.62), { steps: 8 });
+    await page.mouse.up();
+    await page.waitForFunction((z) => window.__trefftzTestHook.getEigenViewport()?.zoom > z, viewportBeforeBox.zoom);
+    const viewportAfterBox = await page.evaluate(() => window.__trefftzTestHook.getEigenViewport());
+    expect(viewportAfterBox.maxRe).toBeLessThan(viewportBeforeBox.maxRe);
+
+    await page.dblclick('#eigenPlot', { position: { x: canvasBox.width * 0.5, y: canvasBox.height * 0.5 } });
+    await page.waitForFunction(() => {
+      const vp = window.__trefftzTestHook.getEigenViewport();
+      return vp && Math.abs(vp.zoom - 1) < 1e-6 && Math.abs(vp.centerRe) < 1e-6 && Math.abs(vp.centerIm) < 1e-6;
+    });
+    const viewportBeforeTouch = await page.evaluate(() => window.__trefftzTestHook.getEigenViewport());
+
     const [download] = await Promise.all([
       page.waitForEvent('download'),
       page.click('#eigenDownload'),
@@ -132,9 +305,9 @@ test('eigenmode panel sits between trefftz and AVL editor, and canvas click sele
     expect(download.suggestedFilename()).toContain('_eigenmodes.csv');
     const downloadPath = await download.path();
     const eigenCsv = await fs.readFile(downloadPath, 'utf8');
-    expect(eigenCsv).toContain('run case,real eigenvalue,imag eigenvalue');
-    expect(eigenCsv).toContain('1,-0.200000,0.120000');
-    expect(eigenCsv).toContain('2,-0.050000,0.020000');
+    expect(eigenCsv).toContain('run case,mode class,real eigenvalue,imag eigenvalue');
+    expect(eigenCsv).toContain('1,Short period,-0.200000,0.120000');
+    expect(eigenCsv).toContain('2,Dutch roll,-0.050000,0.020000');
 
     await page.evaluate(() => {
       const canvas = document.querySelector('#eigenPlot');
@@ -152,35 +325,62 @@ test('eigenmode panel sits between trefftz and AVL editor, and canvas click sele
       canvas.dispatchEvent(makeTouchEvent('touchstart', 100));
       canvas.dispatchEvent(makeTouchEvent('touchmove', 140));
     });
-    await page.waitForFunction((z) => window.__trefftzTestHook.getEigenViewport()?.zoom > z, viewportAfterWheelZoomOut.zoom);
+    await page.waitForFunction((z) => window.__trefftzTestHook.getEigenViewport()?.zoom > z, viewportBeforeTouch.zoom);
     const pointsAfterZoom = await page.evaluate(() => window.__trefftzTestHook.getEigenPoints());
-    const p2 = pointsAfterZoom[0] || points[0];
+    const p2 = pointsAfterZoom.find((point) => point.selectable !== false) || pointsAfterZoom[0] || points[0];
     expect(p2).toBeTruthy();
 
-    await page.evaluate((point) => {
-      const canvas = document.querySelector('#eigenPlot');
-      if (!canvas) return;
-      const rect = canvas.getBoundingClientRect();
-      canvas.dispatchEvent(new MouseEvent('click', {
-        bubbles: true,
-        clientX: rect.left + point.x,
-        clientY: rect.top + point.y,
-      }));
-    }, p2);
+    const selectCanvas = await page.locator('#eigenPlot').boundingBox();
+    expect(selectCanvas).toBeTruthy();
+    await page.waitForTimeout(300);
+    await page.mouse.click(selectCanvas.x + p2.x, selectCanvas.y + p2.y);
 
     await page.waitForFunction((idx) => window.__trefftzTestHook.getSelectedEigenMode() === idx, p2.idx);
 
-    await page.evaluate((point) => {
-      const canvas = document.querySelector('#eigenPlot');
-      if (!canvas) return;
-      const rect = canvas.getBoundingClientRect();
-      canvas.dispatchEvent(new MouseEvent('click', {
-        bubbles: true,
-        clientX: rect.left + point.x,
-        clientY: rect.top + point.y,
-      }));
-    }, p2);
+    await page.mouse.click(selectCanvas.x + p2.x, selectCanvas.y + p2.y);
     await page.waitForFunction(() => window.__trefftzTestHook.getSelectedEigenMode() === -1);
+
+    await expect(page.locator('#eigenDivergence')).toHaveAttribute('aria-pressed', 'false');
+    const decayAnimation = await page.evaluate(() => {
+      const stateOrder = ['u', 'w', 'q', 'theta', 'v', 'p', 'r', 'phi', 'x', 'y', 'z', 'psi'];
+      window.__trefftzTestHook.setEigenModes([{
+        name: 'Unstable pitch',
+        re: 0.8,
+        im: 0.6,
+        runCaseIndex: 0,
+        stateOrder,
+        eigenvector: {
+          re: stateOrder.map((key) => ({ q: 1, theta: 0.8, w: 0.5 }[key] || 0)),
+          im: stateOrder.map(() => 0),
+        },
+        vec: { rx: 0, ry: 0.05, rz: 0, tx: 0.1, ty: 0, tz: 0 },
+      }]);
+      window.__trefftzTestHook.startEigenModeAnimationForTest(0);
+      return window.__trefftzTestHook.setModeAnimationElapsedForTest(6);
+    });
+    expect(decayAnimation.showDivergence).toBe(false);
+    expect(decayAnimation.sigma).toBeLessThan(0);
+    expect(decayAnimation.amplitude).toBeLessThan(1);
+
+    await page.click('#eigenDivergence');
+    await expect(page.locator('#eigenDivergence')).toHaveAttribute('aria-pressed', 'true');
+    const initialGrowthAnimation = await page.evaluate(() => window.__trefftzTestHook.getModeAnimationState());
+    expect(initialGrowthAnimation.showDivergence).toBe(true);
+    expect(initialGrowthAnimation.initialAmplitude).toBeGreaterThan(0);
+    expect(initialGrowthAnimation.initialAmplitude).toBeLessThan(0.2);
+    expect(initialGrowthAnimation.amplitude).toBeGreaterThanOrEqual(initialGrowthAnimation.initialAmplitude);
+    expect(initialGrowthAnimation.amplitude).toBeLessThan(initialGrowthAnimation.initialAmplitude * 1.02);
+    const growthAnimation = await page.evaluate(() => window.__trefftzTestHook.setModeAnimationElapsedForTest(6));
+    expect(growthAnimation.showDivergence).toBe(true);
+    expect(growthAnimation.sigma).toBeGreaterThan(0);
+    expect(growthAnimation.amplitude).toBeGreaterThan(initialGrowthAnimation.amplitude);
+    expect(growthAnimation.amplitude).toBeLessThanOrEqual(growthAnimation.amplitudeCap);
+    expect(growthAnimation.resetPositionError).toBeGreaterThan(growthAnimation.referenceSpan * 2.9);
+    const loopedAnimation = await page.evaluate(() => window.__trefftzTestHook.setModeAnimationElapsedForTest(1000.4167));
+    expect(loopedAnimation.loopCount).toBeGreaterThan(growthAnimation.loopCount);
+    expect(loopedAnimation.elapsed).toBeCloseTo(0, 6);
+    expect(loopedAnimation.positionError).toBeCloseTo(0, 6);
+    expect(loopedAnimation.amplitude).toBeCloseTo(loopedAnimation.initialAmplitude, 6);
   } finally {
     await new Promise((resolve) => server.close(resolve));
   }

--- a/js/playwright/trefftz_axis_label_layout.spec.js
+++ b/js/playwright/trefftz_axis_label_layout.spec.js
@@ -66,6 +66,29 @@ test('trefftz axis labels are outside tick label bounds', async ({ page }) => {
   await page.waitForFunction(() => window.__trefftzTestHook?.layoutReady === true);
 
   await page.waitForSelector('.trefftz-tick.left');
+  await page.waitForSelector('.trefftz-legend-item');
+
+  const legendMetrics = await page.evaluate(() => {
+    const legend = document.querySelector('.trefftz-legend');
+    const item = document.querySelector('.trefftz-legend-item');
+    const swatch = document.querySelector('.trefftz-legend-item .swatch.line');
+    const legendStyle = legend ? getComputedStyle(legend) : null;
+    const itemStyle = item ? getComputedStyle(item) : null;
+    return {
+      itemCount: document.querySelectorAll('.trefftz-legend-item').length,
+      fontSize: legendStyle ? Number.parseFloat(legendStyle.fontSize || '0') : 0,
+      gap: itemStyle ? Number.parseFloat(itemStyle.gap || '0') : 0,
+      itemHeight: item?.getBoundingClientRect().height || 0,
+      swatchWidth: swatch?.getBoundingClientRect().width || 0,
+      swatchHeight: swatch?.getBoundingClientRect().height || 0,
+    };
+  });
+  expect(legendMetrics.itemCount).toBe(4);
+  expect(legendMetrics.fontSize).toBeGreaterThanOrEqual(20);
+  expect(legendMetrics.gap).toBeGreaterThanOrEqual(6);
+  expect(legendMetrics.itemHeight).toBeGreaterThan(14);
+  expect(legendMetrics.swatchWidth).toBeGreaterThanOrEqual(18);
+  expect(legendMetrics.swatchHeight).toBeGreaterThanOrEqual(12);
 
   const measure = async () => page.evaluate(() => {
     const leftLabel = document.querySelector('.trefftz-axis-label.y-left')?.getBoundingClientRect();

--- a/js/playwright/trefftz_hover_cursor.spec.js
+++ b/js/playwright/trefftz_hover_cursor.spec.js
@@ -101,15 +101,36 @@ test('Trefftz and Eigenmodes panels have matching plot height, legend aligns lef
     await expect.poll(async () => {
       const hover = await page.evaluate(() => window.__trefftzTestHook?.trefftzHover || null);
       const spanLabel = String(hover?.spanLabel || '');
+      const markers = Array.isArray(hover?.markers) ? hover.markers : [];
+      const labels = markers.map((marker) => String(marker?.label || ''));
+      const boxes = markers.map((marker) => marker?.labelBox || null);
+      const displayLabels = markers.map((marker) => String(marker?.displayLabel || ''));
+      const readableBoxes = boxes.every((box) => Number(box?.width) > 42 && Number(box?.height) >= 18);
+      const separatedBoxes = boxes.every((box, idx) => idx === 0
+        || (Number(box?.y) >= Number(boxes[idx - 1]?.y) + Number(boxes[idx - 1]?.height) + 2));
       return {
         active: Boolean(hover?.active),
         markerCount: Number(hover?.markerCount || 0),
         hasNumericSpanLabel: /^[-+]?\d+(\.\d+)?$/.test(spanLabel),
+        hasClPerpLabel: labels.some((label) => /^cl_perp\s+[-+]?\d/.test(label)),
+        hasClLabel: labels.some((label) => /^cl\s+[-+]?\d/.test(label)),
+        hasCncLabel: labels.some((label) => /^cl\*c\/cref\s+[-+]?\d/.test(label)),
+        hasAiLabel: labels.some((label) => /^ai\s+[-+]?\d/.test(label)),
+        hasReadableDisplayLabels: displayLabels.includes('Cl perp') && displayLabels.includes('Cl') && displayLabels.includes('Cl*c/Cref'),
+        readableBoxes,
+        separatedBoxes,
       };
     }, { timeout: 20000 }).toEqual({
       active: true,
       markerCount: 4,
       hasNumericSpanLabel: true,
+      hasClPerpLabel: true,
+      hasClLabel: true,
+      hasCncLabel: true,
+      hasAiLabel: true,
+      hasReadableDisplayLabels: true,
+      readableBoxes: true,
+      separatedBoxes: true,
     });
   } finally {
     await new Promise((resolve) => server.close(resolve));


### PR DESCRIPTION
Stack: 2 of 4 in the AVL visualization QoL stack. Depends on PR 1 conceptually; opened against `master` because GitHub cannot target fork-only stack branches as upstream PR bases.

## Summary
- Improve the eigenmode plot with mode classification labels, equal-axis scale lock, pan/box/touch zoom, CSV export, damping guides, and unstable-mode divergence display.
- Improve Trefftz plot readability with better axis/legend layout and richer hover markers, including mobile touch hover persistence.
- Convert viewer/eigen control hover help to custom `aria-label`/`data-tooltip` tooltips with instant display instead of native `title` tooltips.

## Screenshots
![Eigenmode scale lock tooltip](https://raw.githubusercontent.com/ghorn/vibelattice/greg/pr-screenshots/pr-screenshots/avl-visualization-stack/pr2/eigenmode-scale-lock-tooltip.png)

![Trefftz hover and axis layout](https://raw.githubusercontent.com/ghorn/vibelattice/greg/pr-screenshots/pr-screenshots/avl-visualization-stack/pr2/trefftz-hover-axis-legend.png)

## Checks
- `node --check js/dist/app.js`
- `npx playwright test --workers=1 js/playwright/eigenmode_panel.spec.js js/playwright/eigenmode_invalid_mass_message.spec.js js/playwright/trefftz_axis_label_layout.spec.js js/playwright/trefftz_hover_cursor.spec.js`
